### PR TITLE
Require specific jekyll version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Please refer to our [contribution page](http://ms-iot.github.io/content/Contribu
 1. Install [Ruby](http://rubyinstaller.org/downloads/) and add it to your system path environment variable
 1. Install [Ruby DevKit](http://rubyinstaller.org/downloads/), extract into a permanent folder, and add it to your system path environment variable
 1. Install [Python 2.7.7](https://www.python.org/downloads/)
-1. Install jekyll using ruby gems
-```gem install jekyll```
+1. Install jekyll 2.0.3 using ruby gems. (2.1.0 cannot be used at this time)
+```gem install jekyll  --version 2.0.3```
 1. Uninstall pygments.rb - (it currently is incompatible with windows)
 ```gem uninstall pygments.rb```
 1. Install pygments.rb version 0.5.0 using ruby gems
@@ -19,6 +19,6 @@ Please refer to our [contribution page](http://ms-iot.github.io/content/Contribu
 1. from within the content folder
 ```jekyll serve --watch```
 1. If prompted by the firewall, allow Jekyll to serve content
-1. Open your web browser and point it to the local server. [localhost:4000](localhost:4000) is the default
+1. Open your web browser and point it to the local server. [localhost:4000](localhost:4000).
 1. Make changes using [Jekyll's Kramdown flavored Markdown](http://jekyllrb.com/docs/home/)
 


### PR DESCRIPTION
2.1.0 was just released. It requires pygments 0.6.0 which is
incompatible with Windows. We'll have to require 2.0.3 until fixed
