### PR TITLE
Documentation Changes around Tutorials and Remote Debugging

### DIFF
--- a/HelloBlinky.md
+++ b/HelloBlinky.md
@@ -36,44 +36,13 @@ void setup()
 void loop()
 {
   digitalWrite(led, LOW);    // turn the LED off by making the voltage LOW
+  Log(L"LED OFF\n");
   delay(1000);               // wait for a second
   digitalWrite(led, HIGH);    // turn the LED on by making the voltage HIGH
+  Log(L"LED ON\n");
   delay(1000);               // wait for a second
 }
 {% endhighlight %}
-
-  <h3>Configure remote debugging</h3>
-
-  <p>Inside Visual Studio:
-  <ul>
-  <li>select the <kbd>Project</kbd> menu</li>
-  <li>select <kbd><i>Your App's Name</i> Properties</kbd></li>
-  <li>select the <kbd>Debugging</kbd> tree item</li>
-  <li>Change the <kbd>Debugger to launch</kbd> to <kbd>Remote Windows Debugger</kbd></li>
-  <li>Configure the debug page like the following picture, paying close attention to the debug settings:<br>
-  <img src="images\ConfigureRemoteDebugger.png"/></p>
-  </li>
-  </ul>
-  <div class="panel panel-info">
-    <div class="panel-heading">Visual Studio Debug Settings</div>
-    <div class="panel-body">
-      Please change the following settings to configure remote debugging:<br/>
-      Remote Command: <kbd>c:\test\$(TargetFileName)</kbd><br/>
-      Working Directory: <kbd>c:\test</kbd><br/>
-      Remote Server Nane: <kbd>mygalileo</kbd><br/>
-      Deployment Directory: <kbd>c:\test</kbd><br/>
-    </div>
-  </div>
-
-  <div class="panel panel-danger">
-    <div class="panel-heading">Laptop Users please note:</div>
-    <div class="panel-body">If you are connecting Galileo to your laptop either directly or via a USB Ethernet adapter, please disable Wireless. Visual Studio may not find your computer by name if you leave wireless on. </div>
-  </div>
-
-  <h3>Configure remote debugging</h3>
-  Before you close the Property Pages, select the <kbd>Configuration Manager...</kbd> button from the upper right corner.<br/>
-  Make sure "Deploy" is checked for the Hello Blinky project<br/>
-  <img src="images\EnableDeployment.png"/>
 
   <h3>Build and deploy</h3>
   <p>Press F5 to build and deploy your project.</p>

--- a/OnBoardLED.md
+++ b/OnBoardLED.md
@@ -24,14 +24,6 @@ int _tmain(int argc, _TCHAR* argv[])
 //This application flashes the GP LED on the Galileo board by calling the direct GPIO Writes and Sets
 static LONG QUARK_LED_PIN = QRK_LEGACY_RESUME_SUS1; //Uses the Quark legacy GPIO Pins
 bool state = false; // keeps track of the state of the GP LED
-int size = 1000; // the size of our buffer string
-char temp[1000]; // for our buffer string
-
-void CustomLogging(char* str)
-{
-  OutputDebugStringA(str); // for VS Output
-  printf(str); // for commandline output
-}
 
 void setup()
 {
@@ -43,13 +35,13 @@ void loop()
   if (state)
   {
     GpioWrite(QUARK_LED_PIN, 1); // Writes to the pin, setting its value to HIGH
-    CustomLogging("LED OFF\n");
+    Log(L"LED OFF\n");
     state = !state;
   }
   else
   {
     GpioWrite(QUARK_LED_PIN, 0); // Writes to the pin, setting its value to LOW
-    CustomLogging("LED ON\n");
+    Log(L"LED ON\n");
     state = !state;
   }
   Sleep(1000);

--- a/OnBoardThermal.md
+++ b/OnBoardThermal.md
@@ -21,14 +21,8 @@ int _tmain(int argc, _TCHAR* argv[])
 }
 
 int size = 1000; // the size of our buffer string
-char temp[1000]; // for our buffer string
+wchar_t temp[1000]; // for our buffer string
 int tempPin = -1; // The on-board thermal sensor
-
-void CustomLogging(char* str)
-{
-  OutputDebugStringA(str); // for VS Output
-  printf(str); // for commandline output
-}
 
 void setup()
 {
@@ -39,8 +33,7 @@ void loop()
 {
   float temperatureInDegreesCelcius = 1.0f;	// Storage for the temperature value
   temperatureInDegreesCelcius = (float) analogRead(tempPin) / 4.0f;	// reads the analog value from this pin
-  sprintf_s(temp, size, "%lf\n", temperatureInDegreesCelcius);
-  CustomLogging(temp);
+  Log(L"Temperature: %lf\n", temperatureInDegreesCelcius);
   Sleep(100);		// Provides a delay for our visual pleasure
 }
 {% endhighlight %}

--- a/README.md
+++ b/README.md
@@ -4,21 +4,20 @@ Please refer to our [contribution page](http://ms-iot.github.io/content/Contribu
 #Contributing to documentation
 ### Setting up Jekyll on Windows
 1. Install [Ruby](http://rubyinstaller.org/downloads/) and add it to your system path environment variable
-1. Install [Ruby DevKit](http://rubyinstaller.org/downloads/), extract into a permanent folder, and add it to your system path environment variable
+1. Download the [Ruby DevKit](http://rubyinstaller.org/downloads/), and follow the installation instructions (here)[https://github.com/oneclick/rubyinstaller/wiki/Development-Kit]
 1. Install [Python 2.7.7](https://www.python.org/downloads/)
-1. Install jekyll 2.0.3 using ruby gems. (2.1.0 cannot be used at this time)
-```gem install jekyll  --version 2.0.3```
-1. Uninstall pygments.rb - (it currently is incompatible with windows)
+1. Using Command Prompt, Install jekyll 2.0.3 using ruby gems. (2.1.0 cannot be used at this time)
+```gem install jekyll --version 2.0.3```
+1. Using Command Prompt, uninstall pygments.rb - (it currently is incompatible with windows)
 ```gem uninstall pygments.rb```
-1. Install pygments.rb version 0.5.0 using ruby gems
+1. Using Command Prompt, install pygments.rb version 0.5.0 using ruby gems
 ```gem install pygments.rb --version 0.5.0```
 
 ### Iterating on documentation
-1. Launch a GitShell from the GitHub app
-1. Launch your [favorite text editor](http://www.sublimetext.com/).
-1. from within the content folder
+1. Using Command Prompt, from within the content folder start a local server:
 ```jekyll serve --watch```
 1. If prompted by the firewall, allow Jekyll to serve content
-1. Open your web browser and point it to the local server. [localhost:4000](localhost:4000).
-1. Make changes using [Jekyll's Kramdown flavored Markdown](http://jekyllrb.com/docs/home/)
+1. Open your web browser and point it to the local server. localhost:4000 is the default
+1. Now you have your own version of the documentation site!
+1. You can make changes to the pages using your favorite text editor in [Jekyll's Kramdown flavored Markdown](http://jekyllrb.com/docs/home/) or HTML
 

--- a/Tips.md
+++ b/Tips.md
@@ -4,9 +4,78 @@ title: Tips and Tricks
 permalink: /Tips.htm
 ---
 
-# Tips and Tricks
+<div class="jumbotron">
+  <div class="container">
+    <h1>Tips and Tricks</h1>
+  </div>
+</div>
 
 
 ## Making your Galileo run an exe on boot
 Edit the autorun.cmd file in Windows\System32\Boot and add the following line<br/>
 <kbd>start "YourAppLocation\YourAppName"</kbd>
+
+---
+
+## Changing your Galileo's Name
+Through telnet, run SetComputerName using the following line<br/>
+<kbd>SetComputerName {YourNewName}</kbd> <br/>
+
+<div class="panel panel-danger">
+    <div class="panel-heading">Note:</div>
+    <div class="panel-body">If you change your Galileo's name, it will break the remote deployment scripts and you will need to change the settings in your projects.</div>
+</div>
+
+---
+
+<div class="panel-group" id="accordion1">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h4 class="panel-title">
+          <a data-toggle="collapse" data-parent="#accordion1" href="#collapseRemoteDebugging">
+            <h2>Configure remote debugging</h2>
+          </a>
+        </h4>
+      </div>
+      <div id="collapseRemoteDebugging" class="panel-collapse collapse">
+        <div class="panel-body">
+            <p>Inside Visual Studio:
+                <ul>
+                    <li>select the <kbd>Project</kbd> menu</li>
+                    <li>select <kbd><i>Your App's Name</i> Properties</kbd></li>
+                    <li>select the <kbd>Debugging</kbd> tree item</li>
+                    <li>Change the <kbd>Debugger to launch</kbd> to <kbd>Remote Windows Debugger</kbd></li>
+                    <li>Configure the debug page like the following picture, paying close attention to the debug settings:<br>
+                        <img src="images\ConfigureRemoteDebugger.png"/>
+                    </li>
+                </ul>
+            </p>
+            <div class="panel panel-info">
+                <div class="panel-heading">Visual Studio Debug Settings</div>
+                <div class="panel-body">
+                Please change the following settings to configure remote debugging:<br/>
+                Remote Command: <kbd>c:\test\$(TargetFileName)</kbd><br/>
+                Working Directory: <kbd>c:\test</kbd><br/>
+                Remote Server Nane: <kbd>mygalileo</kbd><br/>
+                Deployment Directory: <kbd>c:\test</kbd><br/>
+                <br/>
+                Note: If you want to change the directory that your project is deployed to and run out of you will need to change all of the places it says c:\test\ to your path.<br/>
+                Note: If you change your Galileo's name, you will need to change the Remote Server Name to match.
+                </div>
+            </div>
+            
+            <div class="panel panel-danger">
+                <div class="panel-heading">Laptop Users please note:</div>
+                <div class="panel-body">If you are connecting Galileo to your laptop either directly or via a USB Ethernet adapter, please disable Wireless. Visual Studio may not find your computer by name if you leave wireless on. </div>
+            </div>
+            
+            <h3>Configure remote deploying</h3>
+            Before you close the Property Pages, select the <kbd>Configuration Manager...</kbd> button from the upper right corner.<br/>
+            Make sure "Deploy" is checked for your project<br/>
+            <img src="images\EnableDeployment.png"/><br/>
+        </div>
+      </div>
+    </div>
+  </div>
+  
+  

--- a/TroubleShooting.md
+++ b/TroubleShooting.md
@@ -4,8 +4,14 @@ title: Troubleshooting
 permalink: /TroubleShooting.htm
 ---
 
+<div class="jumbotron">
+  <div class="container">
+    <h1>Troubleshooting</h1>
+  </div>
+</div>
+
 <div class="container">
-  <h3>Troubleshooting Hardware</h3>
+  <h3>Hardware</h3>
   <div class="panel-group" id="accordion1">
     <div class="panel panel-default">
       <div class="panel-heading">
@@ -29,7 +35,7 @@ permalink: /TroubleShooting.htm
     </div>
   </div>
 
-  <h3>Troubleshooting Firmware Update</h3>
+  <h3>Firmware Update</h3>
   <div class="panel-group" id="accordion2">
     <div class="panel panel-default">
       <div class="panel-heading">
@@ -55,7 +61,7 @@ permalink: /TroubleShooting.htm
     </div>
   </div>
 
-  <h3>Troubleshooting Visual Studio</h3>
+  <h3>Visual Studio</h3>
   <div class="panel-group" id="accordion3">
     <div class="panel panel-default">
       <div class="panel-heading">
@@ -80,7 +86,7 @@ permalink: /TroubleShooting.htm
     </div>
   </div>
 
-  <h3>Troubleshooting Windows on Galileo</h3>
+  <h3>Windows on Galileo</h3>
   <div class="panel-group" id="accordion4">
     <div class="panel panel-default">
       <div class="panel-heading">
@@ -113,7 +119,7 @@ permalink: /TroubleShooting.htm
     </div>
   </div>
 
-  <h3>Troubleshooting GalileoWatcher</h3>
+  <h3>GalileoWatcher</h3>
   <div class="panel-group" id="accordian5">
     <div class="panel panel-default">
       <div class="panel-heading">
@@ -129,6 +135,71 @@ permalink: /TroubleShooting.htm
 
           To check it's firewall configurations go to Control Panel > System and Security > Windows Firewall > Allowed Apps</li>
           <img src="images\GalileoWatcherFirewall.png"/>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h3>Remote Deployment</h3>
+  <div class="panel-group" id="accordian6">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h4 class="panel-title">
+          <a data-toggle="collapse" data-parent="#accordian6" href="#collapseRemoteDeployment1">
+            Operation is taking longer than expected
+          </a>
+        </h4>
+      </div>
+      <div id="collapseRemoteDeployment1" class="panel-collapse collapse">
+        <div class="panel-body">
+            Don't freak out! This happens due to the debugging over ethernet.
+        </div>
+      </div>
+    </div>
+    
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h4 class="panel-title">
+          <a data-toggle="collapse" data-parent="#accordian7" href="#collapseRemoteDeployment2">
+            Unable to start debugging. The connection with the remote endpoint was terminated.
+          </a>
+        </h4>
+      </div>
+      <div id="collapseRemoteDeployment2" class="panel-collapse collapse">
+        <div class="panel-body">
+            This can sometimes happen when the name resolution is not working. Try using the IP Address shown for your Galileo in the the GalileoWatcher.
+        </div>
+      </div>
+    </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h4 class="panel-title">
+          <a data-toggle="collapse" data-parent="#accordian9" href="#collapseRemoteDeployment4">
+            Unable to start program 'c:\{File}'. The system cannot find the file specified.
+          </a>
+        </h4>
+      </div>
+      <div id="collapseRemoteDeployment4" class="panel-collapse collapse">
+        <div class="panel-body">
+            <h3>Configure remote deploying for your project</h3>
+            Right click on your project and select Properties.<br/>
+            Select the <kbd>Configuration Manager...</kbd> button from the upper right corner.<br/>
+            Make sure "Deploy" is checked for your project<br/>
+            Also make sure that your remote Debugger settings are set correctly. See <a href="Tips.htm">Configure Remote Debugging</a> in the Tips section.
+        </div>
+      </div>
+    </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h4 class="panel-title">
+          <a data-toggle="collapse" data-parent="#accordian10" href="#collapseRemoteDeployment5">
+            Unable to start debugging. The debugger cannot connect to the remote computer. The debugger was unable to resolve the specified computer name.
+          </a>
+        </h4>
+      </div>
+      <div id="collapseRemoteDeployment5" class="panel-collapse collapse">
+        <div class="panel-body">
+            Make sure your project's remote debugger settings have the correct Remote Server Name. It should match the name of your Galileo board.
         </div>
       </div>
     </div>


### PR DESCRIPTION
Changed HelloBlinky Tutorial to no longer include Remote Debugging commands.
Placed remote debugging instruction in the Tips page.
Added troubleshooting section for remote debugging
Changed README to instruct on using the Command prompt and to simplify iteration instructions
Changed Samples files to include use of the Log function instead of custom Logging
