### PR TITLE
Fixed images paths

### DIFF
--- a/AdvancedUsage.md
+++ b/AdvancedUsage.md
@@ -69,12 +69,12 @@ permalink: /AdvancedUsage.htm
             <p>With your project open in Visual Studio:
                 <ul>
                     <li>Right click on your project (not solution) in the Solution Explorer and select <kbd>Properties</kbd></li>
-                        <img src="images\ConfigureRemoteDebugger1.png"/>
+                        <img src="images/ConfigureRemoteDebugger1.png"/>
                     <li>expand <kbd>Configuration Properties</kbd></li>
                     <li>select the <kbd>Debugging</kbd> tree item</li>
                     <li>Change the <kbd>Debugger to launch</kbd> to <kbd>Remote Windows Debugger</kbd></li>
                     <li>Configure the debug page like the following picture, paying close attention to the debug settings:<br>
-                        <img src="images\ConfigureRemoteDebugger.png"/>
+                        <img src="images/ConfigureRemoteDebugger.png"/>
                     </li>
                 </ul>
             </p>
@@ -95,7 +95,7 @@ permalink: /AdvancedUsage.htm
             <h3>Configure remote deploying</h3>
             Before you close the Property Pages, select the <kbd>Configuration Manager...</kbd> button from the upper right corner.<br/>
             Make sure "Deploy" is checked for your project<br/>
-            <img src="images\EnableDeployment.png"/><br/>
+            <img src="images/EnableDeployment.png"/><br/>
         </div>
     </div>
   </div>

--- a/HelloBlinky.md
+++ b/HelloBlinky.md
@@ -44,7 +44,7 @@ permalink: /HelloBlinky.htm
 
   <h3>Wire your Galileo with an LED</h3>
   <p>LEDs are diodes which will emit light when powered. They are polarized - meaning they work only when plugged in correctly. Typically, the longer leg is the positive lead, so plug it into pin 13 and the shorter leg into ground.</p>
-  <img src="images\HelloBlinky.png"/>
+  <img src="images/HelloBlinky.png"/>
   <p>NOTE: In this sample, we are not protecting the LED with a resistor. It will dim over time. Also, the color of the LED can vary, without creating problems.</p>
 
   <h3>Build and deploy</h3>

--- a/SetupGalileo.md
+++ b/SetupGalileo.md
@@ -70,7 +70,7 @@ permalink: /SetupGalileo.htm
     <li>You should see activity on the microSD light as it boots. The LED is at the bottom left of this picture.</li>
     <br/>
     <p>
-      <img src="images\SDLed.png"/>
+      <img src="images/SDLed.png"/>
     </p>
     <li>
       <b>
@@ -79,12 +79,12 @@ permalink: /SetupGalileo.htm
       <br/>
       Make sure to allow it through the firewall when the security dialog comes up.
       <br/>
-      <img src="images\GalileoWatcherFirewallDialog.PNG">
+      <img src="images/GalileoWatcherFirewallDialog.PNG">
       <br/>
       Once your Galileo board finishes booting up (microSD LED should stop flashing with activity) it should begin broadcasting its IP Address and Host Name. This data should show up on GalileoWatcher like below.
     </li>
     <p>
-      <img src="images\GalileoWatcherExample.png"/>
+      <img src="images/GalileoWatcherExample.png"/>
     </p>
     <br/>
     <li>
@@ -92,7 +92,7 @@ permalink: /SetupGalileo.htm
     </li>
     <br/>
     <p>
-      <img src="images\ping.png"/>
+      <img src="images/ping.png"/>
     </p>
   </ol>
   <hr/>
@@ -102,7 +102,7 @@ permalink: /SetupGalileo.htm
   When prompted by telnet, use the following username and password:<br/>
   <p><kbd>Username: Administrator</kbd><br/>
   <kbd>Password: admin</kbd></p>
-  <p><img src="images\TelnetLogin.png"/></p>
+  <p><img src="images/TelnetLogin.png"/></p>
 
   <h3>Shutting down the Galileo</h3>
   Before you unplug the power from the Galileo, it is advisable to gracefully shut it down. To do this:<br />

--- a/SetupPC.md
+++ b/SetupPC.md
@@ -15,7 +15,7 @@ permalink: /SetupPC.htm
     <div class="panel-body">
         When you are attempting to download anything from Microsoft Connect, you will want to use the link shown below.
         <br/>
-        <img src="images\ConnectDownloadClarification.png" style="height:auto; width:75%;">
+        <img src="images/ConnectDownloadClarification.png" style="height:auto; width:75%;">
     </div>
   </div>
   <hr/>
@@ -151,7 +151,7 @@ permalink: /SetupPC.htm
   <ol>
     <li>On your desktop machine, go to the Control Panel and open:<br/>(if in icon view) Programs and Features<br/> or<br/> (if in category view) Programs -> Programs and Features.</li>
     <li>In the left hand column, select “Turn Windows Features on or off”</li>
-    <li>In the list, “Telnet Client” needs to be checked.<br/><img src="images\Telnet.png"/></li>
+    <li>In the list, “Telnet Client” needs to be checked.<br/><img src="images/Telnet.png"/></li>
     <li>Click "Ok"</li>
     <li>Restart your PC</li>
   </ol>

--- a/TroubleShooting.md
+++ b/TroubleShooting.md
@@ -134,7 +134,7 @@ permalink: /TroubleShooting.htm
           Make sure you have allowed it through the firewall.
 
           To check it's firewall configurations go to Control Panel > System and Security > Windows Firewall > Allowed Apps</li>
-          <img src="images\GalileoWatcherFirewall.png"/>
+          <img src="images/GalileoWatcherFirewall.png"/>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Some images had wrong path. '\' was used instead of '/'. This caused that they weren't displayed. ![2014-07-19 09-27-41-187](https://cloud.githubusercontent.com/assets/4594081/3635536/d9ddf114-0f7a-11e4-8e71-a205fd728bfe.png)
