### PR TITLE
Fixed broken "Configure Remote Debugging" link

### DIFF
--- a/TroubleShooting.md
+++ b/TroubleShooting.md
@@ -198,7 +198,7 @@ permalink: /TroubleShooting.htm
             Right click on your project and select Properties.<br/>
             Select the <kbd>Configuration Manager...</kbd> button from the upper right corner.<br/>
             Make sure "Deploy" is checked for your project<br/>
-            Also make sure that your remote Debugger settings are set correctly. See <a href="Tips.htm">Configure Remote Debugging</a> in the Tips section.
+            Also make sure that your remote Debugger settings are set correctly. See <a href="AdvancedUsage.htm#collapseRemoteDebugging">Configure Remote Debugging</a> on the "Advanced Usage" page.
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixed the broken "Configure Remote Debugging" link in the "Configure
remote deploying for your project" accordion.  Changed it from
"Tips.htm" to "AdvancedUsage.htm#collapseRemoteDebugging"
