### PR TITLE
Ensure proper cast of char to avoid hitting int overload

### DIFF
--- a/UART.md
+++ b/UART.md
@@ -70,7 +70,7 @@ char output = 'a';  // The character being written
 void loop()
 {
     // Handles the writing
-    if (Serial1.write(output) != 1)
+    if (Serial1.write((uint8_t)output) != 1)
     {
         Log(L"Serial1.write failed\n");
     }


### PR DESCRIPTION
There's a bug in the sample code for this sample:
http://ms-iot.github.io/content/UART.htm

In the first line of the loop() method, this line would never return false, causing an error to be logged:
 if (Serial1.write(output) != 1)

The problem is that 'output' will be hitting the 'int' overload, and thus write 4 bytes rather than one. This means the return value is always 4.
Instead adding a cast makes the sample run correctly:
     if (s.write((uint8_t)output) != 1)
