### PR TITLE
Adding link to Glossary from StartCoding and fix formatting

### DIFF
--- a/win10/Glossary.md
+++ b/win10/Glossary.md
@@ -8,46 +8,46 @@ permalink: /win10/Glossary.htm
 
 ##Glossary
 
-**AllJoyn**
+**AllJoyn**<br/>
 AllJoyn is an open source communication framework that enables apps and devices to communicate regardless of connection specifics and OS platform.
 
-**Advanced Configuration & Power Interface (ACPI)**
+**Advanced Configuration & Power Interface (ACPI)**<br/>
 ACPI (Advanced Configuration and Power Interface) is an open industry specification co-developed by Hewlett-Packard, Intel, Microsoft, Phoenix, and Toshiba.  ACPI establishes industry-standard interfaces enabling OS-directed configuration, power management, and thermal management of mobile, desktop, and server platforms.
 
-**Basic Input/Output System (BIOS)**
+**Basic Input/Output System (BIOS)**<br/>
 The set of essential software routines that test hardware at startup, start the operating system, and support the transfer of data among hardware devices.
 
-**General-Purpose Input/Output (GPIO)**
+**General-Purpose Input/Output (GPIO)**<br/>
 GPIO is a generic pin on an integrated circuit whose behavior, including whether it is an input or output pin, can be controlled by the user at run time.  You can use the Windows.Devices.Gpio namespace in your app to manipulate the GPIO pins on your board.
 
-**Headed**
+**Headed**<br/>
 Windows IoT Core can either be in headed or headless mode. The difference between these two modes is the presence or absence of any form of UI. By default, Windows 10 IoT Core is in headed mode and displays system information like the computer name and IP address.
 
-**Headless**
+**Headless**<br/>
 In headless mode, there is no UI stack available and apps are not interactive. Headless mode apps can be thought of as services.
 
-**Inter-Integrated Circuits (I2C)**
+**Inter-Integrated Circuits (I2C)**<br/>
 Simple bidirectional two-wire serial data (SDA) and serial clock (SCL) buses for inter-integrated circuit control.  You can use the Windows.Devices.I2c namespace in your app to communicate with a device over I2C.
 
-**Light-Emitting Diode (LED)**
+**Light-Emitting Diode (LED)**<br/>
 A LED is a two-lead semiconductor light source. It is a pn-junction diode, which emits light when activated.
 
-**Microsoft Windows Kernel Mode Driver Framework (KMDF)**
+**Microsoft Windows Kernel Mode Driver Framework (KMDF)**<br/>
 Microsoft development framework which allows driver developers to expose driver functionality in kernel mode, giving the driver access to system memory and hardware.
 
-**Serial Peripheral Interface Bus (SPI)**
+**Serial Peripheral Interface Bus (SPI)**<br/>
 The SPI bus is a synchronous serial communication interface specification used for short distance communication, primarily in embedded systems.  You can use the Windows.Devices.Spi namespace in your app to communicate with a device over SPI.
 
-**Universal Asynchronous Receiver/Transmitter (UART)**
+**Universal Asynchronous Receiver/Transmitter (UART)**<br/>
 UART is a piece of computer hardware that takes bytes of data and transmits the individual bits serially.
 
-**Universal Windows Platform (UWP)**
+**Universal Windows Platform (UWP)**<br/>
 The Universal Windows Platform provides a guaranteed core API layer across devices.  You can create a single app package that can be installed onto a wide range of devices.
 
-**Virtual Machine (VM)**
+**Virtual Machine (VM)**<br/>
 Software that acts as an interface between compiler binary code and the microprocessor that actually performs the program's instructions.  In Windows, you can use Hyper-V Manager to manage virtual machines.
 
-**Windows Device Console (Devcon.exe)**
-DevCon (Devcon.exe), the Device Console, is a command-line tool that displays detailed information about devices on computers running Windows. You can use DevCon to enable, disable, install, configure, and remove devices.
+**Windows Device Console (Devcon.exe)**<br/>
+DevCon (Devcon.exe), the Device Console, is a command-line tool that displays detailed information about devices on computers running Windows. You can use DevCon to enable, disable, install, configure, and remove devices.  This tool is mostly used for manually installing and removing drivers.
 
 </div>

--- a/win10/StartCoding.md
+++ b/win10/StartCoding.md
@@ -40,7 +40,7 @@ permalink: /win10/StartCoding.htm
                         <a href="{{site.baseurl}}/win10/tools/IoTAPIPortingTool.htm">Learn More</a>
                     </div>
                     <div class="col-md-3">
-                        <h4>Using powershell</h4>
+                        <h4>Using PowerShell</h4>
                         <p>Allows Remote Administration and Configuration so that you can remotely configure and manage any Windows IoT Core device</p>
                         <a href="{{site.baseurl}}/win10/samples/PowerShell.htm">Learn More</a>
                     </div>
@@ -70,6 +70,13 @@ permalink: /win10/StartCoding.htm
                         <h4>Using WINDBG</h4>
                         <p>Use WINDBG to debug</p>
                         <a href="{{site.baseurl}}/win10/Windbg.htm">Learn More</a>
+                    </div>
+                </div>
+                <div class="row section-heading">
+                    <div class="col-md-3">
+                        <h4>Glossary</h4>
+                        <p>A list of commonly used phrases and their meanings</p>
+                        <a href="{{site.baseurl}}/win10/Glossary.htm">Learn More</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
- Put glossary definitions on separate line
- Added link to StartCoding.htm to Glossary
- Fixed capitalization for PowerShell on StartCoding.htm
