### PR TITLE
Fix vcbuild command for Node on Chakra

### DIFF
--- a/win10/samples/Nodejs.md
+++ b/win10/samples/Nodejs.md
@@ -31,7 +31,7 @@ Build for Host (Needed to build the addon):
 Build for the device (assuming Rpi2):
 
 * Goto the cloned repo
-* `vcbuild chakra nosign arm`
+* `vcbuild chakra nosign arm openssl-no-asm`
 
 Update PATH variable (make sure the new Node.exe location is at the front of the path): SET path=C:\NodeChakra;%path%
 


### PR DESCRIPTION
This needs 'openssl-no-asm' in the current version.
