### PR TITLE
Fix cmd to startup windbg

### DIFF
--- a/en-US/win10/Windbg.md
+++ b/en-US/win10/Windbg.md
@@ -123,6 +123,6 @@ As suggested earlier, use the Device Manager on your development PC to find out 
 
 On your development machine you can start WinDbg as follows:
 
-        "C:\Program Files (x86)\Debugging Tools for Windows (x86)\windbg.exe" -k com:port=<PORT> baud=912600
+        "C:\Program Files (x86)\Debugging Tools for Windows (x86)\windbg.exe" -k com:port=<PORT>,baud=912600
 
 * Please note that 'PORT' refers to the COM port number your USB-to-TTL cable was assigned in the system and displayed in the Device Manager under "Ports (COM & LPT)".


### PR DESCRIPTION
copy/pasting the cmd indicated in error upon starting windbg

```
---------------------------
WinDbg:10.0.10240.9 X86 
---------------------------
The command line arguments cannot specify more than one kind of debugging to start
---------------------------
OK   
---------------------------
```

The PR fixes that prblem
