### PR TITLE
Invalid MockAdapterTutorial Image Reference and Typo fixes

### DIFF
--- a/en-US/win10/SetupRPI.md
+++ b/en-US/win10/SetupRPI.md
@@ -72,8 +72,8 @@ Learn how to set up the Raspberry Pi 2 and connect it to your computer.
 <img class="device-images" src="{{site.baseurl}}/images/rpi2.png">
 
 ##Boot Windows 10 IoT Core
-1. Windows 10 IoT Core will boot automatically after connecting power the supply. This will take a few minutes.
-2. Once the device has booted, the DefaultApp will launch and display the IP address of RPi2.
+1. Windows 10 IoT Core will boot automatically after connecting the power supply. This process will take a few minutes.
+2. Once the device has booted, the DefaultApp will launch and display the IP address of your RPi2.
 
 	<img class="device-images" src="{{site.baseurl}}/images/DefaultAppRpi2.png">
 

--- a/en-US/win10/samples/MockAdapterTutorial.md
+++ b/en-US/win10/samples/MockAdapterTutorial.md
@@ -35,7 +35,7 @@ This tutorial demonstrates the function of the AllJoyn Device System Bridge (DSB
 3. Navigate to the extracted folder and open the MockAdapter.sln solution file in Visual Studio.
 4. Once the solution has been opened in Visual Studio, Navigate to the Solution explorer and right click the HeadlessAdapterApp project. Select "Set as Startup Project".
 
-![set_startup]({{site.baseurl}}/images/AllJoyn/mockadapter_vs.png)
+![set_startup]({{site.baseurl}}/images/MockAdapter/mockadapter_vs.png)
 
 5. 	In the Main menu bar, select “Debug” -> HeadlessAdapterApp properties…”
 6.	Follow the instructions to [setup remote debugging and deploy the app]({{site.baseurl}}/{{page.lang}}/win10/AppDeployment.htm#cpp)


### PR DESCRIPTION
Corrected "set as startup project" image reference in
MockAdapterTutorial from AllJoyn to MockAdapter.
