### PR TITLE
HelloWorld readability cleanup and additions.

### DIFF
--- a/en-US/win10/samples/HelloWorld.md
+++ b/en-US/win10/samples/HelloWorld.md
@@ -10,20 +10,19 @@ lang: en-US
 ###Create a new C# project
 You can find the source code for this sample by downloading a zip of all of our samples [here](https://github.com/ms-iot/samples/archive/develop.zip) and navigating to the `samples-develop\HelloWorld`, but as an exercise, this tutorial will take you through the complete steps to create this app from scratch.  
 
-1. Start Visual Studio 2015 RC.
+1. Start Visual Studio 2015.
 
-1. Create a new project (File \| New Project...).
+1. Create a new project `(File \| New Project...)`.
+       
+    * In the `New Project` dialog, navigate to `Universal` as shown below (in the left pane in the dialog: Templates \| Visual C# \| Windows \| Universal).
+    
+1. Select the template `Blank App (Windows Universal)`.
 
-  In the `New Project` dialog, navigate to `Universal` as shown below (in the left pane in the dialog: Templates \| Visual C# \| Windows \| Universal).
+    * Remember to give a good name to your first app! In this example, we called the project 'HelloWorld'.
 
-1. Select the template `Blank App (Windows Universal)`
-
-  Remember to give a good name to your first app! In this example, we called the project 'HelloWorld'.
-
-  ![App Template Location]({{site.baseurl}}/images/HelloWorld/new-cs-project-dialog.PNG)
+    ![App Template Location]({{site.baseurl}}/images/HelloWorld/new-cs-project-dialog.PNG)
 
 > ####A note on Developer Mode for Windows 10
-
 > If this is the first project you create, Visual Studio will likely prompt you to enable Developer Mode for Windows 10.  To do this, you'll need to follow the steps found [here](https://msdn.microsoft.com/library/windows/apps/xaml/dn706236.aspx){:target="_blank"}
 
 ###Add a reference to the Windows IoT extension SDK
@@ -33,45 +32,45 @@ Since the IoT extension SDK is not added to projects by default, we'll need to a
 ![Add Extension SDK]({{site.baseurl}}/images/HelloWorld/Add_IoT_Extension_Reference.PNG)
 
 ###Add content to MainPage.xaml
-  1. Let's add some content to the MainPage. From Solution Explorer, select the 'MainPage.xaml' file. We want to add a TextBox and a Button, to show some interaction. So we will edit the XAML file to add these elements. Locate the `<Grid>` tag in the XAML section of the designer, and add the following markup:
+Let's add some content to the MainPage. From Solution Explorer, select the 'MainPage.xaml' file. We want to add a TextBox and a Button, to show some interaction. So we will edit the XAML file to add these elements. Locate the `<Grid>` tag in the XAML section of the designer, and add the following markup.  
 
-  {% highlight XML %}
-  <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-      <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-      <TextBox x:Name="HelloMessage" Text="Hello, World!" Margin="10" IsReadOnly="True"/>
-      <Button x:Name="ClickMe" Content="Click Me!"  Margin="10" HorizontalAlignment="Center"/>
-      </StackPanel>
-  </Grid>
-  {% endhighlight %}
+{% highlight XML %}
+<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+    <TextBox x:Name="HelloMessage" Text="Hello, World!" Margin="10" IsReadOnly="True"/>
+    <Button x:Name="ClickMe" Content="Click Me!"  Margin="10" HorizontalAlignment="Center"/>
+    </StackPanel>
+</Grid>
+{% endhighlight %}
 
+Now that we have a TextBox and a Button, we can add some code which will be executed when the Button is pressed. Double click on the Button in the design surface: Visual Studio will add a `Click` property to the Button XAML tag and generate the `ClickMe_Click` method in 'MainPage.xaml.cs'. Let's add a simple line of code in this method.
 
-  1. Now that we have a TextBox and a Button, let's add some code which will be executed when the Button is pressed. Double click on the Button in the design surface: Visual Studio will add a `Click` property to the Button XAML tag and generate the `ClickMe_Click` method in 'MainPage.xaml.cs'. Let's add a simple line of code in the method:
-
-  MainPage.xaml:
-  {% highlight XML %}
-  <Button x:Name="ClickMe" Content="Click Me!"  Margin="10" HorizontalAlignment="Center" Click="ClickMe_Click"/>
-  {% endhighlight %}
-
-  MainPage.xaml.cs:
-  {% highlight C++ %}
-  private void ClickMe_Click(object sender, RoutedEventArgs e)
-  {
-      this.HelloMessage.Text = "Hello, Windows IoT Core!";
-  }
-  {% endhighlight %}
+*MainPage.xaml:*
+{% highlight XML %}
+<Button x:Name="ClickMe" Content="Click Me!"  Margin="10" HorizontalAlignment="Center" Click="ClickMe_Click"/>
+{% endhighlight %}
+  
+*MainPage.xaml.cs:*
+{% highlight C# %}
+private void ClickMe_Click(object sender, RoutedEventArgs e)
+{
+    this.HelloMessage.Text = "Hello, Windows IoT Core!";
+}
+{% endhighlight %}
 
 ###Build and test the app locally
-1. Make sure the app builds correctly invoking the Build \| Build Solution menu command.
+1. Make sure the app builds correctly by invoking the Build \| Build Solution menu command.
 
-1. Since this is a Windows Universal App, you can test this on your Visual Studio machine as well: Just press F5, and the app will run inside your machine. You should see something like this:
+1. Since this is a Universal Windows Platform (UWP) application, you can test the app on your Visual Studio machine as well: Just press F5, and the app will run inside your machine. You should see something like this:
 
     ![HelloWorld Running]({{site.baseurl}}/images/HelloWorld/HelloWorldAppLocal.PNG)
 
     Close the app after you're done validating it.
-
+    
+    > If you would like to learn more about Universal Windows Platform applications, click [here](https://msdn.microsoft.com/library/windows/apps/dn894631.aspx){:target="_blank"}.
 
 ###Deploy the app to your Windows IoT Core device
-1. Of course, we want to deploy our first app to our Windows IoT Core device. It's easy. In the [PowerShell]({{site.baseurl}}/{{page.lang}}/win10/samples/PowerShell.htm) documentation, you can find instructions to chose a unique name for your Windows IoT Core device. In this sample, we'll use that name (though you can use your IP address as well) in the 'Remote Machine Debugging' settings in VS.
+1. Of course, we want to deploy our first app to our Windows IoT Core device. It's easy. In the [PowerShell]({{site.baseurl}}/{{page.lang}}/win10/samples/PowerShell.htm) documentation, you can find instructions to chose a unique name for your Windows IoT Core device. In this sample, we'll use that name (though you can use your IP address as well) in the 'Remote Machine Debugging' settings in Visual Studio.
 
     If you're building for Minnowboard Max, select `x86` in the Visual Studio toolbar architecture dropdown.  If you're building for Raspberry Pi 2, select `ARM`.
 
@@ -84,14 +83,14 @@ Since the IoT extension SDK is not added to projects by default, we'll need to a
     ![Remote Machine Debugging]({{site.baseurl}}/images/HelloWorld/cs-remote-connections.PNG)
 
     > Couple of notes:
-
+    >
     > 1. You can use the IP address instead of the Windows IoT Core device name.
-
+    >
     > 2. You can verify and/or modify these values navigating to the project properties (select 'Properties' in the Solution Explorer) and choose the 'Debug' tab on the left:
-
+    >
     > ![Project Properties Debug Tab]({{site.baseurl}}/images/HelloWorld/cs-debug-project-properties.PNG)
 
-1. Now we're ready to deploy to the remote Windows IoT Core device. Simply press F5 (or select Debug \| Start Debugging) to start debugging our app. You should see the app come up in Windows IoT Core device screen, and you should be able to click on the button.
+1. Now we're ready to deploy to the remote Windows IoT Core device. Simply press F5 (or select `Debug \| Start Debugging`) to start debugging our app. You should see the app come up in Windows IoT Core device screen, and you should be able to click on the button.
 
 1. If you see an error message in Visual Studio when deploying that says "Unable to connect to the Microsoft Visual Studio Remote Debugger named 'XXXX'.  The Visual Studio 2015 Remote Debugger (MSVSMON.EXE) does not appear to be running on the remote computer.", the Remote Debugger may have timed out.  Connect to your device using [PowerShell]({{site.baseurl}}/{{page.lang}}/win10/samples/PowerShell.htm) and query the active processes by running `tlist`.  If at least one msvsmon.exe is not present in that list, you'll need to run this command to restart the Remote Debugger (or you can reboot your device): `schtasks /run /tn StartMsvsmon`.
 


### PR DESCRIPTION
Removed reference to Release Candidate from VS2015.
Changed starting structure to sub bullets to keep readability and flow
of intro.

Changed Universal Windows App reference to Universal Windows Platform
as the rest of the guide calls it that.

Removed lines of block text (>) so that when rendered it shows as a
single flowing section and not separate blocks.

Removed number list from adding content to main page. It read as a
conversation instead of explicitly a bullet list.

Added link out to learn more on UWP’s.

Changed VS to Visual Studio as rest of guide uses full name.
