### PR TITLE
Update URL for USB camera sample

### DIFF
--- a/en-US/win10/samples/WebCamSample.md
+++ b/en-US/win10/samples/WebCamSample.md
@@ -13,7 +13,7 @@ This is a headed sample.  To better understand what headed mode is and how to co
   
 ###Load the project in Visual Studio  
   
-You can find the source code for this sample by downloading a zip of all of our samples [here](https://github.com/ms-iot/samples/archive/develop.zip) and navigating to the `samples-develop\WebCamSample`.  Make a copy of the folder on your disk and open the project from Visual Studio.  
+You can find the source code for this sample by downloading a zip of all of our samples [here](https://github.com/ms-iot/samples/tree/develop/WebCamSample/CS){:target="_blank"}. Make a copy of the folder on your disk and open the project from Visual Studio.  
   
 This is a Universal Windows application  
   


### PR DESCRIPTION
The URL was incorrectly pointing to an archived version. Updated to the
correct location
