### PR TITLE
added deprecation warning about galileo to get started.

### DIFF
--- a/en-US/GetStarted.md
+++ b/en-US/GetStarted.md
@@ -15,5 +15,7 @@ Don't have a board yet, and don't know where to begin?  The [Adafruit Starter Pa
 
 {% include devices.html %}
 
+<p>Want to develop for Intel Galileo? Please click <a href="http://ms-iot.github.io/content/en-US/win8/SetupPC.htm">here</a> to get started. Please note that support for Windows on Intel Galileo will end on November 30, 2015.</p>
+
 <h4 class="thin-header"> Have questions about what devices work with each of these boards?  Take a look on our <a target="_blank" href="{{site.baseurl}}/{{page.lang}}/win10/SupportedInterfaces.htm">Supported Peripherals page</a></h4>
 


### PR DESCRIPTION
@windowsondevices Because the deprecation warning follows a liquid-injected html file, it won't compile as markdown.
