### PR TITLE
Refactore AllJoyn samples content

### DIFF
--- a/en-US/win10/AllJoyn.md
+++ b/en-US/win10/AllJoyn.md
@@ -50,21 +50,19 @@ Device System Bridges (DSBs) can help facilitate communication across existing i
 With the [AllJoyn Device System Bridge contribution](https://wiki.allseenalliance.org/gateway/dsb){:target="_blank"} from Microsoft, you can connect existing devices that use BACnet or Z-Wave to an AllJoyn network, thereby enabling existing devices to interact with new AllJoyn devices, as well as enabling cloud connectivity across all devices on the network.   There is also a useful [tool](https://github.com/MS-brock/AllJoynToasterDemo/tree/master/getajxml){:target="_blank"} published which generates AllJoyn introspection XML from an existing AllJoyn device, with usage described in detail in a posting on [channel9.](https://channel9.msdn.com/Blogs/Internet-of-Things-Blog/Step-By-Step-Building-AllJoyn-Universal-Windows-Apps-for-Windows-10-Public-Preview){:target="_blank"}
 Be sure to check out samples and additional documentation below.  We hope you’ll help build many more IoT bridges and contribute your bridges to the AllSeen Alliance.
 
-**Mapping DSB Objects to Alljoyn**
-This document describes the key interfaces and methods used to build the Alljoyn System Bridge
+**AllJoyn Device System Bridge template for Visual Studio 2015**
+This template can be installed in Visual Studio 2015 to enable you to create AllJoyn Device System Bridge projects in both Native C++ and Managed C#.
 
-[AllJoyn DSB API]({{site.baseurl}}/en-US/win10/AlljoynDsbApiGuide.htm){:target="_blank"}
+* [AllJoyn Device System Bridge Template](https://visualstudiogallery.msdn.microsoft.com/aea0b437-ef07-42e3-bd88-8c7f906d5da8){:target="_blank"} - This Visual Studio extension contains both the Native and Managed AllJoyn Device System Bridge templates.
+* [Mapping DSB Objects to AllJoyn]({{site.baseurl}}/en-US/win10/AlljoynDsbApiGuide.htm){:target="_blank"} - This document describes the key interfaces and methods used to build the Alljoyn System Bridge.
 
-**AllJoyn Device System Bridge template for Visual Studio**
-This template can be installed in Visual Studio 2015 Preview to enable you to create AllJoyn Device System Bridge projects.
-* [DeviceSystemBridgeTemplate.vsix](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynDSBGuide/DeviceSystemBridgeTemplate.vsix?raw=true){:target="_blank"} - This vsix contains the AllJoyn Device System Bridge template. Note that this must be copied locally and cannot be installed remotely. You can also find it on [Visual Studio Online](https://visualstudiogallery.msdn.microsoft.com/aea0b437-ef07-42e3-bd88-8c7f906d5da8).
-
+<a name="AllJoynExplorer"/>
 **AllJoyn Explorer**
-This is a tool we use in several points when working with AllJoyn samples. You can find the AllJoyn Explorer [here](https://github.com/ms-iot/samples/tree/develop/AllJoyn/AllJoynExplorer){:target="_blank"}:
+This is a tool we use in several points when working with AllJoyn samples.
 
-* [AllJoyn Explorer](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynExplorer/AllJoynExplorer_1.0.1.9.zip?raw=true){:target="_blank"} - This zip contains the AllJoyn Explorer AppX bundle.
-* [AllJoyn Explorer Setup Guide](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynExplorer/AllJoyn_Explorer_Setup_Guide_v1.0.pdf?raw=true){:target="_blank"} - This pdf contains the documentation for how to deploy the AllJoyn Explorer.
-* [AllJoyn Explorer User Guide](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynExplorer/AllJoyn_Explorer_User_Guide_v1.0.pdf?raw=true){:target="_blank"} - This pdf contains the documentation for how to use the AllJoyn Explorer.
+* [AllJoyn Explorer](https://github.com/ms-iot/samples/releases/download/AllJoynExplorer_1.0.11/AllJoynExplorer_1.0.1.11.zip) - This zip contains the AllJoyn Explorer AppX bundle.
+* [AllJoyn Explorer Setup Guide](https://github.com/ms-iot/samples/releases/download/AllJoynExplorer_1.0.11/AllJoyn_Explorer_Setup_Guide_v1.0.pdf) - This pdf contains the documentation for how to deploy the AllJoyn Explorer.
+* [AllJoyn Explorer User Guide](https://github.com/ms-iot/samples/releases/download/AllJoynExplorer_1.0.11/AllJoyn_Explorer_User_Guide_v1.0.pdf) - This pdf contains the documentation for how to use the AllJoyn Explorer.
 
 **Samples**
 
@@ -87,11 +85,11 @@ This is a tool we use in several points when working with AllJoyn samples. You c
 * [AllJoyn DSB ZigBee Adapter Tutorial and Sample]({{site.baseurl}}/en-US/win10/samples/ZigBeeAdapterTutorial.htm){:target="_blank"}
 
  This tutorial shows how to use the Device System Bridge app to connect your IoT Core devices to ZigBee devices.
-
+ 
 **Additional Resources**
 
-* Building AllJoyn Apps on Windows 10 - [https://channel9.msdn.com/Blogs/Internet-of-Things-Blog/Step-By-Step-Building-AllJoyn-Universal-Windows-Apps-for-Windows-10-Public-Preview](https://channel9.msdn.com/Blogs/Internet-of-Things-Blog/Step-By-Step-Building-AllJoyn-Universal-Windows-Apps-for-Windows-10-Public-Preview){:target="_blank"}
-* AllJoyn Interfaces in Windows 10 - [https://msdn.microsoft.com/en-us/library/windows/apps/xaml/windows.devices.alljoyn.aspx](https://msdn.microsoft.com/en-us/library/windows/apps/xaml/windows.devices.alljoyn.aspx){:target="_blank"}
-* AllJoyn CodeGen Tool - [AllJoynCodeGen.htm]({{site.baseurl}}/en-US/win10/AllJoynCodeGen.htm){:target="_blank"}
-* AllJoyn Architecture Details - [https://allseenalliance.org/developers/learn/](https://allseenalliance.org/developers/learn/){:target="_blank"}
-* AllJoyn Developer Resources - [https://allseenalliance.org/developers/develop/](https://allseenalliance.org/developers/develop/){:target="_blank"}
+* [Channel 9: Building AllJoyn Apps on Windows 10 (MSDN)](https://channel9.msdn.com/Blogs/Internet-of-Things-Blog/Step-By-Step-Building-AllJoyn-Universal-Windows-Apps-for-Windows-10-Public-Preview){:target="_blank"}
+* [AllJoyn Interfaces in Windows 10 (MSDN)](https://msdn.microsoft.com/en-us/library/windows/apps/xaml/windows.devices.alljoyn.aspx){:target="_blank"}
+* [AllJoyn CodeGen Tool]({{site.baseurl}}/en-US/win10/AllJoynCodeGen.htm){:target="_blank"}
+* [AllJoyn Architecture Details (Allseen Alliance)](https://allseenalliance.org/developers/learn/){:target="_blank"}
+* [AllJoyn Developer Resources (Allseen Alliance)](https://allseenalliance.org/developers/develop/){:target="_blank"}

--- a/en-US/win10/AllJoynCodeGen.md
+++ b/en-US/win10/AllJoynCodeGen.md
@@ -61,6 +61,3 @@ The generated classes wrap functionality exposed by the Core C API. Because the 
 The generated code needs to be contained in a component that shares the same interface name as the XML. For example, if the XML for a toaster is defined as com.microsoft.sample.toaster, we would create a runtime component com.microsoft.sample. 
 
 Alternatively, you can name the component whatever you want (e.g. fooCodeGenComponent), but you must manually update the root namespace under the Project properties to be the same as the interface name. (NOTE: you can find the root namespace in the pch.h file that is generated from the AllJoynCodeGen tool). 
-
-
- 

--- a/en-US/win10/AlljoynDsbApiGuide.md
+++ b/en-US/win10/AlljoynDsbApiGuide.md
@@ -125,6 +125,3 @@ The following properties must be implemented for an ISignal
 | :-------------------------- | :--------------------------------- | :-------------------------------------------- |
 | Name	                      |Name of Signal                      | AllJoyn Signal |
 | Params | A set of objects that changed and their new values, or null if this is a pure signal. | Maps to an array of alljoyn signal arguments passed to the signal. |
-
-
-

--- a/en-US/win10/samples/AlljoynDSBSample.md
+++ b/en-US/win10/samples/AlljoynDSBSample.md
@@ -5,17 +5,13 @@ permalink: /en-US/win10/samples/AlljoynDSB_GpioTutorial.htm
 lang: en-US
 ---
 
-## Alljoyn DSB Gpio Sample
+## Alljoyn DSB GPIO Tutorial
 
-This tutorial shows how a GPIO Device can be exposed to the AllJoyn Bus using the AllJoyn Device System Bridge.
+You can find the source code for AllJoyn samples by downloading a zip of all of our samples [here](https://github.com/ms-iot/samples/archive/develop.zip) and navigating to the `samples-develop\AllJoyn`. This tutorial shows how a GPIO Device can be exposed to the AllJoyn Bus using the AllJoyn Device System Bridge.
 
 ### Prerequisites
 
-1. Alljoyn Explorer
-
-* [AllJoyn Explorer](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynExplorer/AllJoynExplorer_1.0.1.9.zip?raw=true){:target="_blank"} - This zip contains the AllJoyn Explorer AppX bundle.
-* [AllJoyn Explorer Setup Guide](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynExplorer/AllJoyn_Explorer_Setup_Guide_v1.0.pdf?raw=true){:target="_blank"} - Manual for installing and launching the AllJoyn Explorer.
-* [AllJoyn Explorer User Guide](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynExplorer/AllJoyn_Explorer_User_Guide_v1.0.pdf?raw=true){:target="_blank"} - this pdf contains the documentation for how to use the AllJoyn Explorer
+1. Install [AllJoyn Explorer]({{site.baseurl}}/en-US/win10/AllJoyn.htm#AllJoynExplorer){:target="_blank"}.
 
 ### Step 1: Hardware Setup
 The sample uses a Raspberry Pi 2 that one of its GPIO pins is connected to a photo resistor as shown in the schematic below. If another device issues the pin number in the code has to be changed to match the HW setup.
@@ -26,8 +22,8 @@ The sample uses a Raspberry Pi 2 that one of its GPIO pins is connected to a pho
 
 The AllJoyn Device System Bridge Template is a Visual Studio extension that enables developers to create an AllJoyn Device System Bridge App project.
 
-1. Dowload the Alljoyn DSB VSIX template from Visual Studio Online [here](https://visualstudiogallery.msdn.microsoft.com/aea0b437-ef07-42e3-bd88-8c7f906d5da8).
-2. After the download, double-click on the DeviceSystemBridgeTemplate.vsix file to install the extension.
+1. Download the Alljoyn DSB VSIX template from Visual Studio Online [here](https://visualstudiogallery.msdn.microsoft.com/aea0b437-ef07-42e3-bd88-8c7f906d5da8){:target="_blank"}.
+2. After the download, double-click on the DeviceSystemBridgeTemplate.vsix file to install the extension. 
 
 ### Step 3: Create an AllJoyn Device System Bridge App Project
 
@@ -196,7 +192,7 @@ Select the "Custom_GPIO_Device" from the list.
 
 ![custom_gpio3_ajx]({{site.baseurl}}/images/AllJoyn/custom_gpio3.png)
 
-## EXTRA CREDIT: Signaling when the GPIO pin value changes
+## EXTRA CREDIT: Signalling when the GPIO pin value changes
 Suppose the applications on the AllJoyn bus do not want to poll the value of the GPIO pin but just to be notified when the GPIO pin value changes. For that, we need to add support for signals in our adapter. The contents below contain all the pieces needed to make the GPIO Device Sample notify the AllJoyn Consumer Applications.
 
 ### Additions to Adapter.h:

--- a/en-US/win10/samples/AlljoynDSBSample_Managed.md
+++ b/en-US/win10/samples/AlljoynDSBSample_Managed.md
@@ -5,17 +5,13 @@ permalink: /en-US/win10/samples/AlljoynDSB_ManagedGpioTutorial.htm
 lang: en-US
 ---
 
-## Alljoyn DSB Gpio C# Sample
+## Alljoyn DSB GPIO C# Tutorial
 
-This tutorial shows how a GPIO Device can be exposed to the AllJoyn Bus using the AllJoyn Device System Bridge in C#.  
+You can find the source code for AllJoyn samples by downloading a zip of all of our samples [here](https://github.com/ms-iot/samples/archive/develop.zip) and navigating to the `samples-develop\AllJoyn`. This tutorial shows how a GPIO Device can be exposed to the AllJoyn Bus using the AllJoyn Device System Bridge in C#.
 
 ### Prerequisites
 
-1. Alljoyn Explorer
-
-* [AllJoyn Explorer](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynExplorer/AllJoynExplorer_1.0.1.9.zip?raw=true){:target="_blank"} - This zip contains the AllJoyn Explorer AppX bundle.
-* [AllJoyn Explorer Setup Guide](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynExplorer/AllJoyn_Explorer_Setup_Guide_v1.0.pdf?raw=true){:target="_blank"} - Manual for installing and launching the AllJoyn Explorer.
-* [AllJoyn Explorer User Guide](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynExplorer/AllJoyn_Explorer_User_Guide_v1.0.pdf?raw=true){:target="_blank"} - this pdf contains the documentation for how to use the AllJoyn Explorer
+1. Install [AllJoyn Explorer]({{site.baseurl}}/en-US/win10/AllJoyn.htm#AllJoynExplorer){:target="_blank"}.
 
 ### Step 1: Hardware Setup  
 The sample uses a Raspberry Pi 2 that one of its GPIO pins is connected to a photo resistor as shown in the schematic below. If another device is sues the pin number in the code has to be changed to match the HW setup.
@@ -26,7 +22,7 @@ The sample uses a Raspberry Pi 2 that one of its GPIO pins is connected to a pho
 
 The AllJoyn Device System Bridge Template is a Visual Studio extension that enables developers to create an AllJoyn Device System Bridge App project.
 
-1. Dowload the Alljoyn DSB VSIX template from Visual Studio Online [here](https://visualstudiogallery.msdn.microsoft.com/aea0b437-ef07-42e3-bd88-8c7f906d5da8).
+1. Download the Alljoyn DSB VSIX template from Visual Studio Online [here](https://visualstudiogallery.msdn.microsoft.com/aea0b437-ef07-42e3-bd88-8c7f906d5da8){:target="_blank"}.
 2. After the download, double-click on the DeviceSystemBridgeTemplate.vsix file to install the extension. 
 
 ### Step 3: Create an AllJoyn Device System Bridge App Project 
@@ -35,7 +31,7 @@ In the Visual Studio, choose File > New > Project which opens the New Project di
 
 ![NewDSB_project]({{site.baseurl}}/images/AllJoyn/new_csharp_proj.png)
 
-You will need to add a reference to the AdapterLib project to use the Windows IoT Extension SDK, which is required to use the Windows::Devices::Gpio API. Follow the below steps to add a refernece to the project:
+You will need to add a reference to the AdapterLib project to use the Windows IoT Extension SDK, which is required to use the Windows::Devices::Gpio API. Follow the below steps to add a reference to the project:
 
   1. In the VS Solution explorer, locate the Adapter Lib project. Expand this project
   2. Right click "References" and select "Add Reference..."
@@ -193,7 +189,7 @@ Select the "Custom_GPIO_Device" from the list
 
 ![custom_gpio3_ajx]({{site.baseurl}}/images/AllJoyn/custom_gpio3.png)
 
-## EXTRA CREDIT: Signaling when the GPIO pin value changes 
+## EXTRA CREDIT: Signalling when the GPIO pin value changes 
 Suppose the applications on the AllJoyn bus do not want to poll the value of the GPIO pin but just to be notified when the GPIO pin value changes. For that, we need to add support for signals in our adapter. The contents below contain all the pieces needed to make the GPIO Device Sample notify the AllJoyn Consumer Applications. 
 
 ### Modify Adapter.cs as follows: 

--- a/en-US/win10/samples/MockAdapterTutorial.md
+++ b/en-US/win10/samples/MockAdapterTutorial.md
@@ -7,19 +7,15 @@ lang: en-US
 
 ##Alljoyn Mock Adapter Sample
 
-[Get the code on Github](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AlljoynMockAdapter/MockAdapter.zip?raw=true)
+You can find the source code for this sample by downloading a zip of all of our samples [here](https://github.com/ms-iot/samples/archive/develop.zip) and navigating to the `samples-develop\AllJoyn\Samples\MockAdapter`.  The sample code is available in C++. Make a copy of the folder on your disk and open the project from Visual Studio.
 
-This tutorial demonstrates the function of the AllJoyn Device System Bridge (DSB) in exposing and controlling mock BACnet devices.
+This tutorial demonstrates the function of the AllJoyn Device System Bridge (DSB) in exposing and controlling mock devices.
 
 ## Prerequisites
 
 1. Raspberry Pi2 running Windows 10 IoT Core build 10240+
 2. PC or Laptop with Windows 10 build 10240+
-3. AllJoyn Explorer (AJX)
-
-  * [AllJoyn Explorer](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynExplorer/AllJoynExplorer_1.0.1.9.zip?raw=true){:target="_blank"} - This zip contains the AllJoyn Explorer AppX bundle.
-  * [AllJoyn Explorer Setup Guide](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynExplorer/AllJoyn_Explorer_Setup_Guide_v1.0.pdf?raw=true){:target="_blank"} - Manual for installing and launching the AllJoyn Explorer.
-  * [AllJoyn Explorer User Guide](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynExplorer/AllJoyn_Explorer_User_Guide_v1.0.pdf?raw=true){:target="_blank"} - this pdf contains the documentation for how to use the AllJoyn Explorer
+3. Install [AllJoyn Explorer]({{site.baseurl}}/en-US/win10/AllJoyn.htm#AllJoynExplorer){:target="_blank"}.
 
 ## Setting up the Raspberry Pi2
 
@@ -27,17 +23,16 @@ This tutorial demonstrates the function of the AllJoyn Device System Bridge (DSB
 2. Connect power to start the Raspberry Pi2
 3. Verify that the PC can access the Raspberry Pi2 with the Windows IoT Core Watcher
 
-## Run the Mock BACnet Adapter in Visual Studio
+## Run the Mock Adapter in Visual Studio
 
-1. Download the MockAdapter.zip file [here](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AlljoynMockAdapter/MockAdapter.zip?raw=true) to a location on your local machine
-2. Navigate to the folder where you downloaded the zip file. Right click the file and "Extract All..." to the folder of your choosing.
-3. Navigate to the extracted folder and open the MockAdapter.sln solution file in Visual Studio.
-4. Once the solution has been opened in Visual Studio, Navigate to the Solution explorer and right click the HeadlessAdapterApp project. Select "Set as Startup Project".
+1. Download a zip of all of our samples [here](https://github.com/ms-iot/samples/archive/develop.zip).
+2. Open `samples-develop\AllJoyn\Samples\MockAdapter\MockAdapter.sln` in Visual Studio.
+3. Navigate to the Solution explorer and right click the HeadlessAdapterApp project. Select "Set as Startup Project".
 
 ![set_startup]({{site.baseurl}}/images/MockAdapter/mockadapter_vs.png)
 
-5. 	In the Main menu bar, select “Debug” -> HeadlessAdapterApp properties…”
-6.	Follow the instructions to [setup remote debugging and deploy the app]({{site.baseurl}}/{{page.lang}}/win10/AppDeployment.htm#cpp)
+4. 	In the Main menu bar, select “Debug” -> HeadlessAdapterApp properties…”
+5.	Follow the instructions to [setup remote debugging and deploy the app]({{site.baseurl}}/{{page.lang}}/win10/AppDeployment.htm#cpp)
 
 ## Controlling the Mock Devices via Alljoyn Explorer
 

--- a/en-US/win10/samples/ZWaveTutorial.md
+++ b/en-US/win10/samples/ZWaveTutorial.md
@@ -5,29 +5,24 @@ permalink: /en-US/win10/samples/ZWaveTutorial.htm
 lang: en-US
 ---
 
-## ZWave Sample
+## Z-Wave Sample
 
-[Get the code on Github](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynZWaveDemo/ZWaveAdapter.zip?raw=true)
+You can find the source code for this sample by downloading a zip of all of our samples [here](https://github.com/ms-iot/samples/archive/develop.zip) and navigating to the `samples-develop\AllJoyn\Samples\ZWaveAdapter`.  The sample code is available in C++. Make a copy of the folder on your disk and open the project from Visual Studio.
 
-This document describes the setup of the AllJoyn Z-Wave demo that is provided at //Build/2015 as part of the Raspberry Pi2 image. It will demonstrate the function of the Z-Wave AllJoyn Device System Bridge (DSB) in exposing and controlling a ZWave device.
+This tutorial demonstrates the function of the AllJoyn Device System Bridge (DSB) in exposing and controlling Z-Wave devices, and describes the setup of the AllJoyn Z-Wave demo that is provided at //Build/2015 as part of the Raspberry Pi2 image. It will demonstrate the function of the Z-Wave AllJoyn Device System Bridge (DSB) in exposing and controlling a Z-Wave device.
 
-### What is ZWave?
+### What is Z-Wave?
 
 Z-Wave is a wireless communications protocol designed to allow devices in the home (lighting, household appliances, for example) to communicate with another for the purposes of home automation.
 
 ## Prerequisites
 
-1. Raspberry Pi2 with //Build/2015 image. This image contains the driver for the Aeon Labs Z-Wave Stick and the Z-Wave DSB.
+1. Raspberry Pi2 with Windows 10 IOT Core image.
 2. <a name="AllJoyn_Z_Wave"></a>Z-Wave devices  Two Aeon Labs Z-Wave devices are needed for this demo:
   * Aeon Labs DSA02203-ZWUS Z-Wave Z-Stick Series 2 USB Dongle
   * Aeon Labs DSC24-ZWUS Smart Switch Z-Wave Appliance Module
-3. PC or Laptop with Windows 10
-  * Public release of Windows 10 – build 10240 or later
-  * AllJoyn Explorer (AJX)
+3. PC or Laptop with Windows 10 with installed [AllJoyn Explorer]({{site.baseurl}}/en-US/win10/AllJoyn.htm#AllJoynExplorer){:target="_blank"}.
 
-  * [AllJoyn Explorer](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynExplorer/AllJoynExplorer_1.0.1.9.zip?raw=true){:target="_blank"} - This zip contains the AllJoyn Explorer AppX bundle.
-  * [AllJoyn Explorer Setup Guide](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynExplorer/AllJoyn_Explorer_Setup_Guide_v1.0.pdf?raw=true){:target="_blank"} - Manual for installing and launching the AllJoyn Explorer.
-  * [AllJoyn Explorer User Guide](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynExplorer/AllJoyn_Explorer_User_Guide_v1.0.pdf?raw=true){:target="_blank"} - this pdf contains the documentation for how to use the AllJoyn Explorer
 
 ## Setting up the Raspberry Pi2
 
@@ -35,23 +30,31 @@ Z-Wave is a wireless communications protocol designed to allow devices in the ho
 2. Connect power to start the Raspberry Pi2
 3. Verify that the PC can access the Raspberry Pi2 with the Windows IoT Core Watcher
 
-## Deploying the ZWave DSB
+## Deploying the Z-Wave DSB
 
-1. Download the ZWaveAdapter.zip file [here](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynZWaveDemo/ZWaveAdapter.zip?raw=true)
-2. Navigate to the folder where you downloaded the zip file. Right click the file and "Extract All..." to the folder of your choosing.
-3. Navigate to the extracted folder and open the ZWaveAdapter.sln solution file in Visual Studio.
-4. Once the solution has been opened in Visual Studio, Navigate to the Solution explorer and right click the ZWaveBackgroundService project. Select "Set as Startup Project". ![set_startup]({{site.baseurl}}/images/AllJoyn/startup_proj.png)
+### To run previously installed
 
-5.  In the Main menu bar, select "Debug" -> ZWaveBackgroundService properties…"
-6.  Follow the instructions to [setup remote debugging and deploy the app]({{site.baseurl}}/{{page.lang}}/win10/AppDeployment.htm#cpp)
+The Z-Wave adapter DSB comes pre-installed for most Windows 10 IOT Core images. In that case, all you need is to launch the sample using SSH or WEBB. 
+
+1. Using [SSH]({{site.baseurl}}/en-US/win10/samples/SSH.htm){:target="_blank"} or [WEBB]({{site.baseurl}}/en-US/win10/tools/Webb.htm){:target="_blank"} run the following command
+   **iotstartup.exe add headless ZWave**
+2. Reboot the device. The Z-Wave adapter application now will be launched on boot.
+
+### To run from source
+1. Download a zip of all of our samples [here](https://github.com/ms-iot/samples/archive/develop.zip).
+2. Open `samples-develop\AllJoyn\Samples\ZWaveAdapter\ZWaveAdapter.sln` in Visual Studio.
+3. Once the solution has been opened in Visual Studio, Navigate to the Solution explorer and right click the ZWaveBackgroundService project. Select "Set as Startup Project". ![set_startup]({{site.baseurl}}/images/AllJoyn/startup_proj.png)
+
+4.  In the Main menu bar, select "Debug" -> ZWaveBackgroundService properties…"
+5.  Follow the instructions to [setup remote debugging and deploy the app]({{site.baseurl}}/{{page.lang}}/win10/AppDeployment.htm#cpp)
 
 ## Pair the Z-Wave device
 
-1. NOTE: Do not plug in the Z-Wave USB dongle yet. Also, the Z-Wave Dongle and Z-Wave switch need to be in close proximity
-2. Tap the circular button to put the Z-Stick in inclusion mode.  The LED should start to blink slowly.
-3. Once the Z-Stick is inclusion mode, plug the Z-Wave switch in (it will not function without being connected to power) and press the power button to add it to the Z-Wave network.  The light on  the controller will blink fast during neighbor discovery and stay solid for 3 seconds to indicate successful inclusion of the device to the network.
-4. Once the LED returns to blinking slowly, tap the button on the Z-Stick again to turn off inclusion mode.
-6. Insert the USB Z-Stick into the RPi2.
+NOTE: Do not plug in the Z-Wave USB dongle when pairing. Also, the Z-Wave Dongle and Z-Wave switch need to be in close proximity
+1. Tap the circular button to put the Z-Stick in inclusion mode.  The LED should start to blink slowly.
+2. Once the Z-Stick is inclusion mode, plug the Z-Wave switch in (it will not function without being connected to power) and press the power button to add it to the Z-Wave network.  The light on  the controller will blink fast during neighbor discovery and stay solid for 3 seconds to indicate successful inclusion of the device to the network.
+3. Once the LED returns to blinking slowly, tap the button on the Z-Stick again to turn off inclusion mode.
+4. Insert the USB Z-Stick into the RPi.
 
 The setup should look like in the picture below
 

--- a/en-US/win10/samples/ZigBeeAdapterTutorial.md
+++ b/en-US/win10/samples/ZigBeeAdapterTutorial.md
@@ -5,8 +5,9 @@ permalink: /en-US/win10/samples/ZigBeeAdapterTutorial.htm
 lang: en-US
 ---
 
-# ZigBee sample
-Get the [code](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynZigBeeAdapter/ZigBeeAdapter.zip?raw=true) on Github
+# ZigBee Adapter sample
+
+You can find the source code for this sample by downloading a zip of all of our samples [here](https://github.com/ms-iot/samples/archive/develop.zip) and navigating to the `samples-develop\AllJoyn\Samples\ZigBeeAdapter`.  The sample code is available in C#. Make a copy of the folder on your disk and open the project from Visual Studio.
 
 This document describes the setup of the ZigBee adapter for Device System Bridge (DSB) on Windows 10. When using it you will be able to expose ZigBee devices to AllJoyn.
 
@@ -14,25 +15,25 @@ This document describes the setup of the ZigBee adapter for Device System Bridge
 
 ZigBee is a low cost, low power, wireless communications standard designed to allow devices to communicate with another. In addition to the communication protocol, ZigBee standard also defines profiles, such as ZigBee Light Link or Home Automation, which themselves define device. For example, ZigBee Light Link will define what a light is, what a dimmable light is, and so on. Each device uses clusters defined in the ZigBee Cluster Library (ZCL) to specify what they can do, what they expose…
 
-See [ZigBee standard](http://www.zigbee.org) for more information about ZigBee, ZigBee profiles, ZCL clusters...
+See [ZigBee standard](http://www.zigbee.org){:target="_blank"} for more information about ZigBee, ZigBee profiles, ZCL clusters...
 
 Acronyms:
 - ZDO: ZigBee Device Object
 - ZCL: ZigBee Cluster Library
 
 ## Prerequisites
-1. XBee ZigBee module from [Digi](http://www.digi.com), e.g.: XB24 Z7PIT-004
-2. XBee Explorer USB dongle from [SparkFun](https://www.sparkfun.com/products/11697)
-3. [XCTU](http://www.digi.com/products/xbee-rf-solutions/xctu-software/xctu) tool from Digi
-4. Windows 10 desktop with Visual Studio 2015 and [AllJoyn Explorer (AJX)](http://ms-iot.github.io/content/en-US/win10/AllJoyn.htm)
-5. [FTDI driver](http://www.ftdichip.com/Drivers/D2XX.htm) for Windows 10 which is required by the XBee Explorer USB dongle.
+1. XBee ZigBee module from [Digi](http://www.digi.com){:target="_blank"}, e.g.: XB24 Z7PIT-004
+2. XBee Explorer USB dongle from [SparkFun](https://www.sparkfun.com/products/11697){:target="_blank"}
+3. [XCTU](http://www.digi.com/products/xbee-rf-solutions/xctu-software/xctu){:target="_blank"} tool from Digi
+4. Windows 10 desktop with Visual Studio 2015 and [AllJoyn Explorer (AJX)]({{site.baseurl}}/en-US/win10/AllJoyn.htm){:target="_blank"}
+5. [FTDI driver](http://www.ftdichip.com/Drivers/D2XX.htm){:target="_blank"} for Windows 10 which is required by the XBee Explorer USB dongle.
 6. Some ZigBee devices like
- - [Philips Hue](http://www2.meethue.com/en-US) light bulb
- - [Dresden Elektronik](https://www.dresden-elektronik.de) ballast FLS-PP-IP that control a colored LED band 
+ - [Philips Hue](http://www2.meethue.com/en-US){:target="_blank"} light bulb
+ - [Dresden Elektronik](https://www.dresden-elektronik.de){:target="_blank"} ballast FLS-PP-IP that control a colored LED band 
 
 > Note that it is very important that the __ZigBee devices__ you will use __are not__ already __part of a ZigBee network__ otherwise they will not join your ZigBee network. Consequently, it is safer to buy single Philips Hue light bulb instead of a set of bulbs bundled with Philips Hue gateway because in that case bulbs will be part of the ZigBee network controlled by the gateway. 
   
-AllJoyn Explorer and its documentation (how to install, to use…) can be find [here](http://ms-iot.github.io/content/en-US/win10/AllJoyn.htm).
+AllJoyn Explorer and its documentation can be found [here]({{site.baseurl}}/en-US/win10/AllJoyn.htm#AllJoynExplorer){:target="_blank"}.
 
 ![ZigBeeHardware]({{site.baseurl}}/images/ZigBee/ZigBeeHardware.png)
 
@@ -56,7 +57,7 @@ Set up loopback exception:
  4. Restart your applications.
 
 ## Configure your XBee ZigBee module using XCTU tool
-Please look at the tool help to get more details about the tool (https://docs.digi.com/display/XCTU/XCTU+Overview).
+Please look at the tool help to get more details about the tool (https://docs.digi.com/display/XCTU/XCTU+Overview){:target="_blank"}.
 
 ![XBeeConfig1]({{site.baseurl}}/images/ZigBee/XBeeConfig1.png)
 
@@ -70,24 +71,16 @@ You can verify that devices have by using “network discovery” feature of XCT
 ![ZigBeeJoinNetVerif]({{site.baseurl}}/images/ZigBee/ZigBeeJoinNetVerif.png)
 
 ## Set up your Raspberry Pi2
-1. Perform initial set up as instructed [here](http://ms-iot.github.io/content/en-US/win10/SetupRPI.htm)
+1. Perform initial set up as instructed [here]({{site.baseurl}}/en-US/win10/SetupRPI.htm){:target="_blank"}
 2. Plug the XBee USB dongle into the Raspberry Pi2
-3. Install the FTDI driver if not already part of the Windows 10 image for Raspberry Pi2
- 4. Start a remote powershell session as administrator to the Raspberry Pi2
- 5. Copy the .inf and .sys file of the FTDI driver to c:\windows\system32 folder of the RaspBerry Pi2
- 6. Install the FTDI drivers using the following command:  `devcon.exe dp_add FTDIBUS.inf` and `devcon.exe dp_add FTDIPORT.inf`
- 7. Verify that driver works using the following command:  `devcon status "USB\VID_0403&PID_6001"`.
-You should see something like that: "_USB\VID_0403&PID_6001\... Name: FT232R USB UART Driver is running_".
-Note that PID could also be 6015 instead of 6001. This depends on the XBee Explorer USB dongle your using. 
- 8. Reboot the RaspBerry Pi2
 
 ## Deploy the ZigBee adapter on your Windows 10 machine
-1. Download the ZigBeeAdapter.zip file [here](https://github.com/ms-iot/samples/blob/develop/AllJoyn/AllJoynZigBeeAdapter/ZigBeeAdapter.zip?raw=true)
-2. Navigate to the folder where you downloaded the zip file. Right click the file and “Extract All…” to the folder of your choice.
-3. Navigate to the extracted folder and open the ZigBeeAdapter.sln solution file in Visual Studio.
-4. Select the relevant target (x86, x64 or ARM) and build the solution in Visual Studio.
+
+1. Download a zip of all of our samples [here](https://github.com/ms-iot/samples/archive/develop.zip).
+2. Open `samples-develop\AllJoyn\Samples\ZigBeeAdapter\ZigBeeAdapter.sln` in Visual Studio.
+3. Select the relevant target (x86, x64 or ARM) and build the solution in Visual Studio.
 Your now ready to launch it, so launch or debug HeadedAdapterApp project on desktop or if the targeted Windows 10 device has a display or launch or debug HeadlessAdapterApp if it doesn’t. 
-If needed, see instruction [here](http://ms-iot.github.io/content/en-US/win10/AppDeployment.htm) for remote debugging.
+If needed, see instruction [here]({{site.baseurl}}/en-US/win10/AppDeployment.htm){:target="_blank"} for remote debugging.
  
  
 ### Known limitations of the current version of the ZigBee adapter
@@ -200,4 +193,3 @@ Explicit addressing ZigBee Command
 Explicit Rx Indicator
 
 ![XBeeFrame3]({{site.baseurl}}/images/ZigBee/XBeeFrame3.png)
-


### PR DESCRIPTION
As part of fix for https://github.com/ms-iot/samples/issues/64, AllJoyn samples is moving to source form, and AllJoyn Explorer binaries are moved out of samples. Pull request has been submitted: https://github.com/ms-iot/samples/pull/157

This is a corresponding content side change that also needs to be merged.
Note that this is touching existing live content, and that content needs to be updated with the samples changes.
