### PR TITLE
Fix broken link due to case sensitive URIs

### DIFF
--- a/en-US/win10/samples/AllJoynJS.md
+++ b/en-US/win10/samples/AllJoynJS.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: AllJoyn.JS
-permalink: /en-US/win10/samples/AlljoynJS.htm
+permalink: /en-US/win10/samples/AllJoynJS.htm
 lang: en-US
 ---
 


### PR DESCRIPTION
Fix broken link due to case sensitive URIs. Note that it does work without the fix on Jekyll.
