### PR TITLE
Update SMB.md

### DIFF
--- a/en-US/win10/samples/SMB.md
+++ b/en-US/win10/samples/SMB.md
@@ -12,7 +12,7 @@ lang: en-US
 
     ![DefaultApp on Windows IoT Core]({{site.baseurl}}/images/DefaultApp.png)
     
-* Once you have the IP, open up **File Explorer** on your computer and type `\\<TARGET_DEVICE>\c$`, where `<TARGET_DEVICE>` is either the name or the IP Address of your Windows IoT Core device, then hit Enter.  Enter your administrator username and password if prompted.
+* Once you have the IP, open up **File Explorer** on your computer and type `\\<TARGET_DEVICE>\c$`, where `<TARGET_DEVICE>` is either the name or the IP Address of your Windows IoT Core device, then hit Enter.  Enter your administrator username and password if prompted. The username should be prefixed with the IP Address of your Windows IoT Core device. Example: '192.168.1.118\Administrator'.
 
     ![File explorer]({{site.baseurl}}/images/smb/smb_file_explorer.png)
 


### PR DESCRIPTION
In the login dialog, prefixing the username with the the Windows IoT Core device IP Address is required to gain access. Example: '192.168.1.118\Administrator'. This frustrated me for awhile so I think others may make the same mistake.
