### PR TITLE
update flash tool name

### DIFF
--- a/en-US/win10/SetupRPI.htm
+++ b/en-US/win10/SetupRPI.htm
@@ -22,7 +22,7 @@
     <div class="row">
       <div class="col-md-6 col-sm-12">
         <li>
-          Double click on the ISO (Iot Core RPi.iso). It will automatically mount itself as a virtual drive so you can access the contents.
+          Double click on the ISO (10586.0.151029-1700.TH2_Release_IOTCoreRPi_armFRE.iso). It will automatically mount itself as a virtual drive so you can access the contents.
         </li>
       </div>
       <div class="col-md-6 col-sm-12">
@@ -62,22 +62,22 @@
     <div class="row">
       <div class="col-md-6 col-sm-12">
         <li>
-           Use IoTCoreImageHelper.exe to flash the SD card. Search for "WindowsIoT" from start menu and select the shortcut "WindowsIoTImageHelper".
+           Use <a href="http://go.microsoft.com/fwlink/?LinkID=708576" target="_blank">Windows 10 IoT Core Dashboard</a> to flash the SD card. Search for "WindowsIoT" from start menu and select the shortcut "WindowsIoTImageHelper".
         </li>
       </div>
       <div class="col-md-6 col-sm-12">
-        <img alt=”screenshot: search for IoTCoreImageHeloper.exe to flash the sd card” src="{{site.baseurl}}/images/ImagerHelperSearch.PNG">
+        <img alt=”screenshot: search for Dashboard to flash the sd card” src="{{site.baseurl}}/images/ImagerHelperSearch.PNG">
       </div>
     </div>
     <div class="row">
       <div class="col-md-6 col-sm-12">
         <li>
           <p>The tool will enumerate devices as shown. Select the SD card you want to flash, and then provide the location of the ffu to flash the image.</p>
-          <p><b>NOTE:</b> IoTCoreImageHelper.exe is the recommended tool to flash the SD card. However, instructions are available for using <a href="{{site.baseurl}}/{{page.lang}}/win10/samples/DISM.htm" target="_blank">DISM command line tool</a> directly.</p>
+          <p><b>NOTE:</b> Dashboard is the recommended tool to flash the SD card. However, instructions are available for using <a href="{{site.baseurl}}/{{page.lang}}/win10/samples/DISM.htm" target="_blank">DISM command line tool</a> directly.</p>
         </li>
       </div>
       <div class="col-md-6 col-sm-12">
-        <img alt=”screenshot: IoTCoreImageHeloper.exe to flash the sd card” src="{{site.baseurl}}/images/SetupRPI/ImageHelper.PNG">
+        <img alt=”screenshot: Dashboard to flash the sd card” src="{{site.baseurl}}/images/SetupRPI/ImageHelper.PNG">
       </div>
     </div>
     <div class="row">

--- a/en-US/win10/SetupRPI.htm
+++ b/en-US/win10/SetupRPI.htm
@@ -62,7 +62,7 @@
     <div class="row">
       <div class="col-md-6 col-sm-12">
         <li>
-           Use <a href="http://go.microsoft.com/fwlink/?LinkID=708576" target="_blank">Windows 10 IoT Core Dashboard</a> to flash the SD card. Search for "WindowsIoT" from start menu and select the shortcut "WindowsIoTImageHelper".
+           Use <a href="http://go.microsoft.com/fwlink/?LinkID=708576" target="_blank">Windows 10 IoT Core Dashboard</a> to flash the SD card. Search for "Dashboard" from start menu and select the shortcut "Windows 10 IoT Core Dashboard".
         </li>
       </div>
       <div class="col-md-6 col-sm-12">


### PR DESCRIPTION
this specific page still pointed to IoTCore Image Helper as the flashing tool for the IoTCore image/.ffu. 
the respective pictures still need to be updated as I don't have uploading rights. I attached the corresponding screenshots to VS Bug 6666575
