### PR TITLE
Fix preview with Jekyll & look&feel of GetStarted pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _site
 Gemfile.lock
 _config.dev.yml
 .jekyll-metadata
+.vscode

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,8 +14,9 @@
 
     <!-- Bootstrap core CSS -->
     <script type="text/javascript" src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-2.1.1.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://dev.windows.com/content/WebCore.4.3.0.ltr.light.min.css" />
-    <!--<link href="{{site.baseurl}}/Resources/css/bootstrap.css" rel="stylesheet" />-->
+    <script type="text/javascript" src="//ajax.aspnetcdn.com/ajax/bootstrap/3.3.0/bootstrap.min.js"></script>
+
+    <link rel="stylesheet" type="text/css" href="https://assets.onestore.ms/cdnfiles/external/webcore/4.7.0/stylesheets/WebCore.4.7.0.ltr.light.min.css" />
     <link href="{{site.baseurl}}/Resources/css/pygments.css" rel="stylesheet" />
     <link href="{{site.baseurl}}/Resources/css/main.css" rel="stylesheet" />
     {% include css-base.html %}

--- a/en-US/GetStarted.htm
+++ b/en-US/GetStarted.htm
@@ -16,13 +16,9 @@ lang: en-US
         </ol>
         <header class="page-title-header">
             <h1 class="page-title">Get Started with Windows IoT </h1>
+            <h2 class="page-subtitle">Download the tools and software you need to set up your board, build and explore Windows IoT </h2>
         </header>
     </div>
-</div>
-<div class="row">
-  <div class="col-xs-24">
-    <h2 class="subtext">Download the tools and software you need to set up your board, build and explore Windows IoT </h2>
-  </div>
 </div>
 
 <h2>1. Get Windows 10 <span class="pull-right"><a id="get-windows-toggle" class="toggle-button" onClick="hideDiv('get-windows')">Hide</a></span></h2>

--- a/en-US/win10/GetStarted/ConfigureBoard.md
+++ b/en-US/win10/GetStarted/ConfigureBoard.md
@@ -1,7 +1,11 @@
-<p>Once you have successfully connected your board to the network, you can return to the “My devices” tab to configure the name and password.</p>
-<ol class="inline-list">
-  <li><b>Find your device in the list, and click the edit symbol (pencil symbol)</b>. This will take you to settings page. From the settings page you can launch Windows Device Portal, and set basic settings. </li>
-  <li><b>Set your name and change your password (highly recommended)</b>. All devices start with a default password. The <b>default password is “p@ssw0rd”</b>. We highly suggest you change it.</li> 
-</ol>
-<img src="{{site.baseurl}}/Resources/images/get-started/dashboard-4.png" />
+<div class="col-md-12 col-xs-24 col-no-padding">
+  <p>Once you have successfully connected your board to the network, you can return to the “My devices” tab to configure the name and password.</p>
+  <ol class="inline-list">
+    <li><b>Find your device in the list, and click the edit symbol (pencil symbol)</b>. This will take you to settings page. From the settings page you can launch Windows Device Portal, and set basic settings. </li>
+    <li><b>Set your name and change your password (highly recommended)</b>. All devices start with a default password. The <b>default password is “p@ssw0rd”</b>. We highly suggest you change it.</li> 
+  </ol>
+</div>
 
+<div class="col-md-10 col-xs-24">
+  <img src="{{site.baseurl}}/Resources/images/get-started/dashboard-4.png" />
+</div>

--- a/en-US/win10/GetStarted/ConnectToNetwork.md
+++ b/en-US/win10/GetStarted/ConnectToNetwork.md
@@ -1,19 +1,22 @@
-<p>There are currently two ways to get connected depending on what kind of equipment you have; WiFi and ethernet. <b>Connecting via Ethernet is recommended</b> because of it’s reliability.</p>
-<p>Connect via ethernet:</p>
-<ol class="inline-list">
-  <li><b>Connect an Ethernet cable from your network into your board.</b> The board will automatically connect to your network.</li>
-  <li><b>Go to "My Devices".</b> From my devices, you can discover your device and configure it (including connecting to Wi-Fi).</li>
-</ol>
+<div class="col-md-12 col-xs-24 col-no-padding">
+  <p>There are currently two ways to get connected depending on what kind of equipment you have; WiFi and ethernet. <b>Connecting via Ethernet is recommended</b> because of it’s reliability.</p>
+  <p>Connect via ethernet:</p>
+  <ol class="inline-list">
+    <li><b>Connect an Ethernet cable from your network into your board.</b> The board will automatically connect to your network.</li>
+    <li><b>Go to "My Devices".</b> From my devices, you can discover your device and configure it (including connecting to Wi-Fi).</li>
+  </ol>
 
-<p>Connect via Wi-Fi:</p>
-<ol class="inline-list">
-  <li><b>Go to "My devices".</b> my devices, you can dsicover your device and configure it (including connecting to Wi-Fi).</li>  
-  <li><b>Find your board and click "Configure Device".</b> If your board has a WiFi adapater and it has not yet be set up, it will start to broadcast itself as a network (shown in the figure to the right). Unconfigured boards will begin with "AJ_" (e.g. AJ_58EA6C68).
-  If you don’t see your board, make sure that you’ve allowed enough time for your board to boot. If all else fails, reboot your device.
-  <li><b>Enter your network credentials.</b> Your computer will now connect to your board.</li> 
-</ol>
+  <p>Connect via Wi-Fi:</p>
+  <ol class="inline-list">
+    <li><b>Go to "My devices".</b> my devices, you can dsicover your device and configure it (including connecting to Wi-Fi).</li>  
+    <li><b>Find your board and click "Configure Device".</b> If your board has a WiFi adapater and it has not yet be set up, it will start to broadcast itself as a network (shown in the figure to the right). Unconfigured boards will begin with "AJ_" (e.g. AJ_58EA6C68).
+    If you don’t see your board, make sure that you’ve allowed enough time for your board to boot. If all else fails, reboot your device.
+    <li><b>Enter your network credentials.</b> Your computer will now connect to your board.</li> 
+  </ol>
+</div>
 
-<img src="{{site.baseurl}}/Resources/images/get-started/dashboard-2.png" />
-<br />
-<img src="{{site.baseurl}}/Resources/images/get-started/dashboard-3.png" />
-
+<div class="col-md-10 col-xs-24">
+  <img src="{{site.baseurl}}/Resources/images/get-started/dashboard-2.png" />
+  <br />
+  <img src="{{site.baseurl}}/Resources/images/get-started/dashboard-3.png" />
+</div>

--- a/en-US/win10/GetStarted/DownloadAndFlash.md
+++ b/en-US/win10/GetStarted/DownloadAndFlash.md
@@ -1,12 +1,16 @@
-<p>To set up Windows 10 IoT Core, you need to use the Windows 10 IoT Core Dashboard.</p>
-<ol class="inline-list">
-  <li><b>Launch Windows 10 IoT Core Dashboard</b>. If you haven't already, <a href="http://ms-iot.github.io/content/en-US/GetStarted.htm" target="_blank">install Windows 10 IoT Core Dashboard</a>. Note that you must have Windows 10 or better.</li>
-  <li><b>Click "Set up a new device"</b>.</li>
-  <li><b>Select your device type from the dropdown</b>. Each board has its own specialized image that differs per board.</li>
-  <li><b>Make sure your SD card is compliant</b>. We require that the SD card be at least 8 GB in size. Slower and older cards have a tendency to be inconsistent when flashing and may fail to work.
-  For best results, use our suggested cards in our <a href="http://ms-iot.github.io/content/en-US/win10/SupportedInterfaces.htm#Storage" target="_blank">compatibility list</a>.</li> 
-  <li><b>Download and install</b>. A window will pop up to show you the progress of the flashing. This can take several minutes depending on the speed of your card.</li> 
-  <li><b>Plug the SD card into your board and power on</b>. You have the option to plug in a display, but it is not necessary. For best results, plug it in before you power on the device. First boot will take several minutes as the Operating System does its initial installation.
-</ol>
+<div class="col-md-12 col-xs-24 col-no-padding">
+  <p>To set up Windows 10 IoT Core, you need to use the Windows 10 IoT Core Dashboard.</p>
+  <ol class="inline-list">
+    <li><b>Launch Windows 10 IoT Core Dashboard</b>. If you haven't already, <a href="http://ms-iot.github.io/content/en-US/GetStarted.htm" target="_blank">install Windows 10 IoT Core Dashboard</a>. Note that you must have Windows 10 or better.</li>
+    <li><b>Click "Set up a new device"</b>.</li>
+    <li><b>Select your device type from the dropdown</b>. Each board has its own specialized image that differs per board.</li>
+    <li><b>Make sure your SD card is compliant</b>. We require that the SD card be at least 8 GB in size. Slower and older cards have a tendency to be inconsistent when flashing and may fail to work.
+    For best results, use our suggested cards in our <a href="http://ms-iot.github.io/content/en-US/win10/SupportedInterfaces.htm#Storage" target="_blank">compatibility list</a>.</li> 
+    <li><b>Download and install</b>. A window will pop up to show you the progress of the flashing. This can take several minutes depending on the speed of your card.</li> 
+    <li><b>Plug the SD card into your board and power on</b>. You have the option to plug in a display, but it is not necessary. For best results, plug it in before you power on the device. First boot will take several minutes as the Operating System does its initial installation.</li>
+  </ol>
+</div>
 
-<img src="{{site.baseurl}}/Resources/images/get-started/dashboard-1.png" />
+<div class="col-md-10 col-xs-24">
+  <img src="{{site.baseurl}}/Resources/images/get-started/dashboard-1.png" />
+</div>

--- a/en-US/win10/GetStarted/QuickRunSamples.md
+++ b/en-US/win10/GetStarted/QuickRunSamples.md
@@ -1,8 +1,12 @@
-<p>Quick-Run samples are pre-built and require no compiling or coding to get going. This is a great way to make sure everything is working and easily play with your board.</p>
-<ol class="inline-list">
-  <li><b>Navigate to "Quick-run samples"</b> in the left nav bar.</li>
-  <li><b>Select a sample.</b></li> 
-  <li><b>Select your board from the drop down list and launch the sample.</b>  In the background, the dashboard will temporarily install the quick-run sample onto you device. Once loaded, the device will broadcast a webpage over the network and IoT Dashboard will automatically connect to it. This lets you control the app without having to plug in a monitor directly to your device.</li>
-</ol>
+<div class="col-md-12 col-xs-24 col-no-padding">
+  <p>Quick-Run samples are pre-built and require no compiling or coding to get going. This is a great way to make sure everything is working and easily play with your board.</p>
+  <ol class="inline-list">
+    <li><b>Navigate to "Quick-run samples"</b> in the left nav bar.</li>
+    <li><b>Select a sample.</b></li> 
+    <li><b>Select your board from the drop down list and launch the sample.</b>  In the background, the dashboard will temporarily install the quick-run sample onto you device. Once loaded, the device will broadcast a webpage over the network and IoT Dashboard will automatically connect to it. This lets you control the app without having to plug in a monitor directly to your device.</li>
+  </ol>
+</div>
 
-<img src="{{site.baseurl}}/Resources/images/get-started/dashboard-5.png" />
+<div class="col-md-10 col-xs-24">
+  <img src="{{site.baseurl}}/Resources/images/get-started/dashboard-5.png" />
+</div>

--- a/en-US/win10/GetStarted/SetUpVisualStudio.htm
+++ b/en-US/win10/GetStarted/SetUpVisualStudio.htm
@@ -25,15 +25,14 @@ lang: en-US
     </span></p>
 </div>
 
-<div class="row">
-  <div class="col-xs-24">
-    <h2>Get Visual Studio <span class="pull-right"><a id="get-vs-toggle" class="toggle-button" onClick="hideDiv('get-vs')">Hide</a></span></h2>
-    <hr>
-    <div id="get-vs" class="toggle-section">
+<h2>Get Visual Studio <span class="pull-right"><a id="get-vs-toggle" class="toggle-button" onClick="hideDiv('get-vs')">Hide</a></span></h2>
+<hr>
+<div id="get-vs" class="toggle-section">
+  <div class="row">
     {% include_relative SetupPCContent.md %}
-    </div>
-  </div>>
-</div>>
+  </div>
+</div>
+<br>
 <br>
 
 <div class="row">

--- a/en-US/win10/GetStarted/SetUpYourDevice.htm
+++ b/en-US/win10/GetStarted/SetUpYourDevice.htm
@@ -19,56 +19,59 @@ lang: en-US
   </div>
 </div>
 
-<p>
-The instructions on this page are for Windows 10 IoT Core RTM (no sign up required), but if you are a member of the Insider Program (or want to signup) you can:
- </p>
-     <p><span>
-        <a href="{{site.baseurl}}/{{page.lang}}/win10/GetStarted/SetUpYourDeviceManually.htm" class="button-blue button-flat">Get the latest Insider Preview for your Raspberry Pi 2 or 3.</a>
+<div class="row">
+  <div class="col-xs-24">
+    <p>The instructions on this page are for Windows 10 IoT Core RTM (no sign up required), but if you are a member of the Insider Program (or want to signup) you can:</p>
+  </div>
+  <div class="col-md-12 col-xs-24 col-no-padding">
+    <p>
+      <span><a href="{{site.baseurl}}/{{page.lang}}/win10/GetStarted/SetUpYourDeviceManually.htm" class="button-blue button-flat">Get the latest Insider Preview for your Raspberry Pi 2 or 3.</a></span>
+    </p>
+  </div>
+</div>
+
+<div class="row">
+    <p><span class="pull-right">
+        <a href="{{site.baseurl}}/{{page.lang}}/win10/GetStarted/SetUpVisualStudio.htm" class="button-blue button-flat">Next: Set up Visual Studio</a>
     </span></p>
+</div>
  
-<div class="row">
-  <div class="col-xs-24">
-    <h2>Download and flash <span class="pull-right"><a id="download-and-flash-toggle" class="toggle-button" onClick="hideDiv('download-and-flash')">Hide</a></span></h2>
-    <hr />
-    <div id="download-and-flash" class="toggle-section">
-      {% include_relative DownloadAndFlash.md %}
-    </div>
+<h2>Download and flash <span class="pull-right"><a id="download-and-flash-toggle" class="toggle-button" onClick="hideDiv('download-and-flash')">Hide</a></span></h2>
+<hr />
+<div id="download-and-flash" class="toggle-section">
+  <div class="row">
+    {% include_relative DownloadAndFlash.md %}
   </div>
 </div>
-<br />
+<br>
 
-<div class="row">
-  <div class="col-xs-24">
-    <h2>Connect the board to the network <span class="pull-right"><a id="connect-to-network-toggle" class="toggle-button" onClick="hideDiv('connect-to-network')">Hide</a></span></h2>
-    <hr />
-    <div id="connect-to-network" class="toggle-section">
-      {% include_relative ConnectToNetwork.md %}
-    </div>
+<h2>Connect the board to the network <span class="pull-right"><a id="connect-to-network-toggle" class="toggle-button" onClick="hideDiv('connect-to-network')">Hide</a></span></h2>
+<hr />
+<div id="connect-to-network" class="toggle-section">
+  <div class="row">
+    {% include_relative ConnectToNetwork.md %}
   </div>
 </div>
-<br />
+<br>
 
-<div class="row">
-  <div class="col-xs-24">
-    <h2>Configure your board <span class="pull-right"><a id="configure-board-toggle" class="toggle-button" onClick="hideDiv('configure-board')">Hide</a></span></h2>
-    <hr />
-    <div id="configure-board" class="toggle-section">
-      {% include_relative ConfigureBoard.md %}
-    </div>
+<h2>Configure your board <span class="pull-right"><a id="configure-board-toggle" class="toggle-button" onClick="hideDiv('configure-board')">Hide</a></span></h2>
+<hr />
+<div id="configure-board" class="toggle-section">
+  <div class="row">
+    {% include_relative ConfigureBoard.md %}
   </div>
 </div>
-<br />
+<br>
 
-<div class="row">
-  <div class="col-xs-24">
-    <h2>Quick-run samples <span class="pull-right"><a id="quick-run-samples-toggle" class="toggle-button" onClick="hideDiv('quick-run-samples')">Hide</a></span></h2>
-    <hr>
-    <div id="quick-run-samples" class="toggle-section">
-      {% include_relative QuickRunSamples.md %}
-    </div>
+<h2>Quick-run samples <span class="pull-right"><a id="quick-run-samples-toggle" class="toggle-button" onClick="hideDiv('quick-run-samples')">Hide</a></span></h2>
+<hr>
+<div id="quick-run-samples" class="toggle-section">
+  <div class="row">
+    {% include_relative QuickRunSamples.md %}
   </div>
 </div>
-<br />
+<br>
+<br>
 
 <div class="row">
     <p><span class="pull-right">

--- a/en-US/win10/GetStarted/SetupPCContent.md
+++ b/en-US/win10/GetStarted/SetupPCContent.md
@@ -1,13 +1,18 @@
-<p>To setup your Windows 10 IoT Core development PC, you first need to set up Visual Studio 2015 Update 1 on your PC. Install the following:</p>
-<ol class="inline-list">
-  <li><b>Make sure you are running the public release of Windows 10 (version 10.0.10240) or better</b>. You can upgrade from <a href="http://www.microsoft.com/en-us/software-download/windows10" target="_blank">here</a>. If you are already running Windows 10, you can find your current build number by clicking the start button, typing "winver", and hitting enter.</li>
-  <li><b>Install Visual Studio Community 2015 <a href="http://go.microsoft.com/fwlink/?LinkID=534599" target="_blank">here</a>.</b> Visual Studio Professional 2015 and Visual Studio Enterprise 2015 can be downloaded from <a href="https://www.visualstudio.com/vs-2015-product-editions" target="_blank">here</a>.
-  <p> NOTE: If you choose to install a different edition of Visual Studio 2015, make sure to do a Custom install and select the checkbox Universal Windows App Development Tools -> Tools and Windows SDK.</p>
-  </li>
-  <li><b>Update Visual Studio 2015</b>.If you already have Visual Studio 2015 installed, install Update 1 from the Extensions and Updates dialog in Visual Studio or from <a href="http://go.microsoft.com/fwlink/?LinkID=691134" target="_blank">here</a>
-  <p> NOTE: If you already have the Univeral Windows App Development tools (UWP Tools), they will be updated. If you don't have the UWP Tools, you can add them to Visual Studio.</p>
-  </li>
-  <li><b>Validate your Visual Studio installation.</b> Selecting Help > About Microsoft Visual Studio will display version information.  The required version of Visual Studio is 14.0.24720.00 Update 1. The required version of Visual Studio Tools for Universal Windows Apps is 14.0.24720.00.</li>      <li><b>Install Windows IoT Core Project Templates</b> from <a href="https://visualstudiogallery.msdn.microsoft.com/55b357e1-a533-43ad-82a5-a88ac4b01dec" target="_blank">here</a>.  Alternatively, the templates can be found by searching for Windows IoT Core Project Templates in the <a href="https://visualstudiogallery.msdn.microsoft.com/" target="_blank">Visual Studio Gallery</a> or directly from Visual Studio in the Extension and Updates dialog (Tools > Extensions and Updates > Online).</li>
-  <li> <b>Enable developer mode</b> on your Windows 10 device by following <a href="https://msdn.microsoft.com/library/windows/apps/xaml/dn706236.aspx" target="_blank">these instructions</a>.  The relevant portion of the linked instructions is the "Windows 10 Desktops/tablets" section, as you should be attempting setup with one of these devices.</li>
-</ol>
-<img src="{{site.baseurl}}/Resources/images/setup-pc.png" />
+<div class="col-md-12 col-xs-24 col-no-padding">
+  <p>To setup your Windows 10 IoT Core development PC, you first need to set up Visual Studio 2015 Update 1 on your PC. Install the following:</p>
+  <ol class="inline-list">
+    <li><b>Make sure you are running the public release of Windows 10 (version 10.0.10240) or better</b>. You can upgrade from <a href="http://www.microsoft.com/en-us/software-download/windows10" target="_blank">here</a>. If you are already running Windows 10, you can find your current build number by clicking the start button, typing "winver", and hitting enter.</li>
+    <li><b>Install Visual Studio Community 2015 <a href="http://go.microsoft.com/fwlink/?LinkID=534599" target="_blank">here</a>.</b> Visual Studio Professional 2015 and Visual Studio Enterprise 2015 can be downloaded from <a href="https://www.visualstudio.com/vs-2015-product-editions" target="_blank">here</a>.
+    <p> NOTE: If you choose to install a different edition of Visual Studio 2015, make sure to do a Custom install and select the checkbox Universal Windows App Development Tools -> Tools and Windows SDK.</p>
+    </li>
+    <li><b>Update Visual Studio 2015</b>.If you already have Visual Studio 2015 installed, install Update 1 from the Extensions and Updates dialog in Visual Studio or from <a href="http://go.microsoft.com/fwlink/?LinkID=691134" target="_blank">here</a>
+    <p> NOTE: If you already have the Univeral Windows App Development tools (UWP Tools), they will be updated. If you don't have the UWP Tools, you can add them to Visual Studio.</p>
+    </li>
+    <li><b>Validate your Visual Studio installation.</b> Selecting Help > About Microsoft Visual Studio will display version information.  The required version of Visual Studio is 14.0.24720.00 Update 1. The required version of Visual Studio Tools for Universal Windows Apps is 14.0.24720.00.</li>      <li><b>Install Windows IoT Core Project Templates</b> from <a href="https://visualstudiogallery.msdn.microsoft.com/55b357e1-a533-43ad-82a5-a88ac4b01dec" target="_blank">here</a>.  Alternatively, the templates can be found by searching for Windows IoT Core Project Templates in the <a href="https://visualstudiogallery.msdn.microsoft.com/" target="_blank">Visual Studio Gallery</a> or directly from Visual Studio in the Extension and Updates dialog (Tools > Extensions and Updates > Online).</li>
+    <li> <b>Enable developer mode</b> on your Windows 10 device by following <a href="https://msdn.microsoft.com/library/windows/apps/xaml/dn706236.aspx" target="_blank">these instructions</a>.  The relevant portion of the linked instructions is the "Windows 10 Desktops/tablets" section, as you should be attempting setup with one of these devices.</li>
+  </ol>
+</div>
+
+<div class="col-md-10 col-xs-24">
+  <img src="{{site.baseurl}}/Resources/images/setup-pc.png" />
+</div>


### PR DESCRIPTION
Added right links to head.htm to fix the preview with Jekyll (still not perfect)

The two column layout we wanted for the GetStarted pages got messed up somehow, so we fixed that
