### PR TITLE
Adding back the internet connection sharing doc

### DIFF
--- a/_data/_docsandtutorials.json
+++ b/_data/_docsandtutorials.json
@@ -155,6 +155,13 @@
          "ranking": 10,
          "tags": [ "advanced" ]
       },
+	  {
+         "title":"Enabling Internet Connection Sharing",
+         "description":"Learn how to enable Internet Connection Sharing on your IoT Core device by bridging a Software Wi-Fi Access Point and Ethernet adapter",
+         "link-text":"<a href='InternetConnectionSharing.htm'>Learn More</a>",
+         "ranking":20,
+         "tags":["advanced"]
+      },	  
       {
          "title": "Remote display experience for Windows 10 IoT Core",
          "description": "Learn how to put a display on any displayless device with this new technology.",


### PR DESCRIPTION
Bug # 7592882 WoD.com: Accidentally removed "Enabling Internet Connection Sharing" doc and tutorial
