### PR TITLE
Add Docs and Samples pages (which are split from the original StartCo…

### DIFF
--- a/en-US/win10/Docs.md
+++ b/en-US/win10/Docs.md
@@ -1,0 +1,39 @@
+---
+layout: default
+title: Docs
+description: Documentation to demonstrate proven concepts and to help you start coding.
+keyword: windows iot, docs, download
+permalink: /en-US/win10/Docs.htm
+lang: en-US
+---
+<div class="row">
+  <div class="col-xs-24">
+    <ol class="breadcrumb">
+      <li><a href="https://developer.microsoft.com/en-us/windows/iot">IoT Home</a></li>
+      <li class="active">Docs</li>
+    </ol>
+    <header class="page-title-header">
+      <h1 class="page-title">Docs</h1>
+    </header>
+  </div>
+</div>
+
+<div class="row section-heading">
+  <div class="col-md-12">    
+    <p>Docs to help you use tools and resources to help you develop.</p>
+    <br/>
+    <h4>Did you set up your environment?</h4>
+    <p>We assume you already <a href="{{site.baseurl}}/{{page.lang}}/GetStarted.htm">set up your environment</a>, have a working Visual Studio and have a device running Windows IoT Core (Raspberry Pi 2 or 3, or MinnowBoard Max, or DragonBoard).</p>
+    <br/>
+    <h4>Questions/Suggestions</h4>
+    <p>Remember, you can always <a href="{{site.baseurl}}/{{page.lang}}/Community.htm#contact">contact us</a> for help and suggestions!</p>
+    <br/>
+  </div>
+  <div class="col-md-12">
+    <img src="{{site.baseurl}}/Resources/images/DevelopmentBoards.PNG" alt="Development Boards" class="img-responsive">
+  </div>
+</div>
+
+<div class="section">
+  {% include _docsandtutorials.html %}
+</div>

--- a/en-US/win10/Samples.md
+++ b/en-US/win10/Samples.md
@@ -1,0 +1,41 @@
+---
+layout: default
+title: Samples
+description: Code samples to demonstrate proven concepts and to help you start coding.
+keyword: windows iot, samples, download
+permalink: /en-US/win10/Samples.htm
+lang: en-US
+---
+<div class="row">
+  <div class="col-xs-24">
+    <ol class="breadcrumb">
+      <li><a href="https://developer.microsoft.com/en-us/windows/iot">IoT Home</a></li>
+      <li class="active">Samples</li>
+    </ol>
+    <header class="page-title-header">
+      <h1 class="page-title">Samples</h1>
+    </header>
+  </div>
+</div>
+
+<div class="row section-heading">
+  <div class="col-md-12">    
+    <p>Download code samples to get started with Windows on Devices.</p>
+    <br/>
+    <h4>Did you set up your environment?</h4>
+    <p>We assume you already <a href="{{site.baseurl}}/{{page.lang}}/GetStarted.htm">set up your environment</a>, have a working Visual Studio and have a device running Windows IoT Core (Raspberry Pi 2 or 3, or MinnowBoard Max, or DragonBoard).</p>
+    <br/>
+    <h4>Questions/Suggestions</h4>
+    <p>Remember, you can always <a href="{{site.baseurl}}/{{page.lang}}/Community.htm#contact">contact us</a> for help and suggestions!</p>
+    <br/>
+    <h4>How To Download These Samples</h4>
+    <p>The easiest way to download these samples is to navigate to the GitHub repo ms-iot/samples by clicking <a href="https://github.com/ms-iot/samples">here</a>, and then click on the Download ZIP button on the right-hand menu.  Once you download and unzip the file locally, you will be able to see all the samples.</p>
+  </div>
+  <div class="col-md-12">
+    <img src="{{site.baseurl}}/Resources/images/DevelopmentBoards.PNG" alt="Development Boards" class="img-responsive">
+  </div>
+</div>
+
+<div class="section">
+  {% include _samples.html %}
+</div>


### PR DESCRIPTION
…ding page).

Note that for now I left StartCoding unchanged, and no links reference to new Docs and Samples pages.
They ready to be referenced (and then StartCoding should be removed, along with various links to it).
