### PR TITLE
Rpi2: Fix power-on pull of GPIOs 9, 10, 11

### DIFF
--- a/en-US/win10/samples/PinMappingsRPi2.md
+++ b/en-US/win10/samples/PinMappingsRPi2.md
@@ -34,9 +34,9 @@ The following GPIO pins are accessible through APIs:
 | 6     | PullUp        |                     | 31                 |
 | 7     | PullUp        | SPI0 CS1            | 26                 |
 | 8     | PullUp        | SPI0 CS0            | 24                 |
-| 9     | PullUp        | SPI0 MISO           | 21                 |
-| 10    | PullUp        | SPI0 MOSI           | 19                 |
-| 11    | PullUp        | SPI0 SCLK           | 23                 |
+| 9     | PullDown      | SPI0 MISO           | 21                 |
+| 10    | PullDown      | SPI0 MOSI           | 19                 |
+| 11    | PullDown      | SPI0 SCLK           | 23                 |
 | 12    | PullDown      |                     | 32                 |
 | 13    | PullDown      |                     | 33                 |
 | 16    | PullDown      | SPI1 CS0            | 36                 |


### PR DESCRIPTION
Reported by [Bjornono](https://social.msdn.microsoft.com/Forums/en-US/94535bf5-09d1-4b23-ae79-ead0291a7d1a/raspberry-pi-23-boot-up-status-on-gpio-pins-and-not-available-pins?forum=WindowsIoT)
