### PR TITLE
Clarify fTPM instructions

### DIFF
--- a/en-US/win10/TPM.md
+++ b/en-US/win10/TPM.md
@@ -39,8 +39,8 @@ The TPM provides cryptographic functions designed to provide trust in the platfo
 _A few words about sTPM, fTPM, dTPM..._
 
 ### Firmware TPM (fTPM)  
-Firmware TPM (fTPM) requires special Processor/SoC support that is not currently implemented on Raspberry Pi 2 or 3. MinnowBoard Max needs firmware version 0.80 or higher. DragonBoard410c provides fTPM capabilities out of the box.  
-Instructions on how to set up fTPM on Windows IoT Core are available [here][1].
+Firmware TPM (fTPM) requires special Processor/SoC support that is not currently implemented on Raspberry Pi 2 or 3. MinnowBoard Max needs firmware version 0.80 or higher. DragonBoard410c provides fTPM capabilities out of the box enabled by default.  
+Instructions on how to set up fTPM on Intel MBM are available [here][1].
 
 ### Discrete TPM (dTPM)  
 Discrete TPM (dTPM) is considered the utmost trustworthy solution by all means.  


### PR DESCRIPTION
fTPM is enabled by default on DragonBoard. Setup instructions apply for MBM only.
