### PR TITLE
removed 'Max' from the Minnowboard button

### DIFF
--- a/en-US/GetStarted.htm
+++ b/en-US/GetStarted.htm
@@ -48,7 +48,7 @@ lang: en-US
           </li>
           <li id="mbmButton" class="win-color-border-20 win-color-bg-0 iot-getstarted-buttons" onclick="boardButtonClick('mbm')">
               <img style="max-width:75%;" src="{{site.baseurl}}/Resources/images/minnowboard-max.png">
-              <p class="text-caption">Minnowboard Max</p>
+              <p class="text-caption">Minnowboard</p>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
The Minnowboard OS image works with ALL the MinnowBoards (Max, Turbot etc).  Removing 'Max' will be clearer for users to choose Minnowboard for all their OS install.  It also helps in other instructions off-site to not have to mention to use "Max" even though you have a "Turbot" etc.  This helps with Usability and User Experience.