### PR TITLE
added current 'Turbot' version of the MinnowBoard to button

### DIFF
--- a/en-US/GetStarted.htm
+++ b/en-US/GetStarted.htm
@@ -48,7 +48,7 @@ lang: en-US
           </li>
           <li id="mbmButton" class="win-color-border-20 win-color-bg-0 iot-getstarted-buttons" onclick="boardButtonClick('mbm')">
               <img style="max-width:75%;" src="{{site.baseurl}}/Resources/images/minnowboard-max.png">
-              <p class="text-caption">Minnowboard Max</p>
+              <p class="text-caption">Minnowboard Max / Turbot</p>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
The IoT image works on both the 'Max' and 'Turbot' versions of the MinnowBoard.  Adding this label will be clearer for users and more accurate.