### PR TITLE
Redirect IoTDashboardTroubleshooting.htm page

### DIFF
--- a/en-US/Docs/IoTDashboardTroubleshooting.htm
+++ b/en-US/Docs/IoTDashboardTroubleshooting.htm
@@ -1,49 +1,7 @@
 ---
-layout: default
+layout: redirect
 title: Windows 10 IoT Core Dashboard
 permalink: /en-US/Docs/IoTDashboardTroubleshooting.htm
 lang: en-US
 ---
-<ol class="breadcrumb">
-  <li>
-    <a href="https://developer.microsoft.com/en-us/windows/iot">IoT Home</a>
-  </li>
-  <li>
-    <a href="{{site.baseurl}}/{{page.lang}}/GetStarted">Get Started</a>
-  </li>
-  <li class="active">Windows 10 IoT Core Dashboard</li>
-</ol>
-<h1 class="page-title"> Windows 10 IoT Core Dashboard </h1>
-<div class="row">
-  <div class="col-md-12 col-sm-24 col-no-padding">
-    <h2 class="subtext">IoT Dashboard is the best way to download, set up and connect your Windows 10 IOT Core devices, all from your pc. </h2>
-  </div>
-</div>
-
-
-<h2>Troubleshooting </h2>
-
-<hr>
-  <div id="app-content" class="toggle-section">
-  <div class="row">
-    <div class="col-md-12 col-sm-24">
-        <p>If your device is running a build older than build 10586, you must upgrade in order to Windows 10 IoT Core Dashboard to work correctly </p>
-     <h3> Flashing the SD Card </h3>
-        <p>Some SD cards have been noted to not be compatible with Windows 10 IoT Core.  For best results, use our suggested cards in our <a href = "http://ms-iot.github.io/content/en-US/Docs/HardwareCompatList.htm#Storage" target ="_blank"> compatibility list </a>. </p>
-     <h3> Setting up Wi-Fi </h3>
-        <p>Note: Setting up Wi-Fi on the Raspberry Pi 2 has been noted to be unreliable. If setup fails, you may need to repeat the setup experience </p>
-        <p>Note: The official Raspberry pi2 Wi-Fi adapter can be unstable when connecting to Wi-Fi. For a list of supported Wi-Fi Adapters, see our <a href = "http://ms-iot.github.io/content/en-US/Docs/HardwareCompatList.htm#WiFi-Dongles" target ="_blank"> compatibility list </a></p>
-        <p>After downloading and flashing Windows 10 IoT Core onto your SD card, insert the SD card into your device. Your device should automatically appear in "My Devices" after your device finishes booting up. This could take a couple of minutes. If you plug in a monitor to your device, it will show you the boot progress. </p>
-        <p>If your device does not show up after a minute, manually restart and wait for it to boot up. </p>
-        <p>Once you discover and connect to your device, your device should show with a randomly generated name starting with "AJ_". </p>
-        
-        <h4>Still having problems?</h4>
-        <p>If you continue to have problems getting your device connect, <b>plug in an Ethernet cable</b> into your device. Ethernet has proven to be more reliable than Wi-Fi for some users. </p>
-
-    </div>
-    <div class="col-md-12 col-sm-24">
-      <img src="{{site.baseurl}}/Resources/images/DeviceCenter.png">
-    </div>
-</div>
-
-
+{% include redirect.html url="/windows/iot/Docs" %}


### PR DESCRIPTION
This IoTDashboardTroubleshooting page is no longer used though is discoverable so will now redirect