### PR TITLE
Add Windows Firewall settings to IoTDashboard.md

### DIFF
--- a/en-US/Docs/IoTDashboard.md
+++ b/en-US/Docs/IoTDashboard.md
@@ -20,6 +20,7 @@ Windows 10 IoT Core Dashboard is the best way to download, set up and connect yo
 ___
 The IoT Dashboard makes it easy to set up a new device. For detailed instructions on how to get started, see the [Get Started]({{site.baseurl}}/{{page.lang}}/GetStarted) page.
 
+
 {% include imageborder.html alt="IoT Dashboard Setup Page" link="/Resources/images/IoTDashboard/IoTDashboard_SetupPage.PNG" %}
 
 ### SD card
@@ -55,7 +56,14 @@ Having your IoT Core device connect to the internet is essential. Many of the ne
 ## My Devices
 ___
 After your device is connected to the internet, the IoT Dashboard will automatically detect your device.
-To find your device, go to **My Devices**. If your device is not listed, try rebooting the device. Also make sure that if there are more than one devices on the network, they each have a unique name.
+To find your device, go to **My Devices**. If your device is not listed, try rebooting the device. Also make sure that if there are more than one devices on the network, they each have a unique name. Also make sure that your Windows Firewall settings allow **windows10iotcoredashboard.exe** as follows:
+
+1. Open **Network and Sharing Center** and then see which type in Domain, Private or Public of the network your device is connected belongs to.
+2. Open **Control Panel** and click **System and Security**.
+3. Click **Allow an app through Windows Firewall** under **Windows Firewall**.
+4. Click **Change settings**.
+5. Find **windows10iotcoredashboard.exe** in **Allowed apps and features** and then enable the appropriate network check box (i.e. the network type of Domain, Private or Public you can find in the step 1).
+
 
 ### Connect to your device
 Right click and select **Open in Device Portal**. This will launch the [Windows Device Portal]({{site.baseurl}}/{{page.lang}}/Docs/Tools/DevicePortal) page and is the best way to interact and manage your device.


### PR DESCRIPTION
Add Windows Firewall settings to IoTDashboard.md because without this settings we cannot see any IoT device which auto-connecting through Wi-Fi. This change is allowed by Rachit Bajpai (rachitb), but he and/or his team will review this.