### PR TITLE
InternalDetectObjects takes 5 arguments not 3

### DIFF
--- a/en-US/Samples/OpenCV.md
+++ b/en-US/Samples/OpenCV.md
@@ -345,7 +345,7 @@ void OpenCVExample::MainPage::detectFeaturesButton_Click(Platform::Object^ sende
     std::vector<cv::Rect> faces;
     std::vector<cv::Rect> bodies;
     // run object detection
-    InternalDetectObjects(frame, faces, bodies);
+    InternalDetectObjects(frame, faces, bodies, face_cascade, body_cascade);
     // draw red rectangles around detected faces
     for (unsigned int i = 0; i < faces.size(); i++)
     {


### PR DESCRIPTION
In line 348 you are calling "InternalDetectObjects" but you are passing only 3 parameters and that function takes 5 parameters, it needs to take the cascade files, so I just included them in the function call.