### PR TITLE
Remove rendered triple backtick

### DIFF
--- a/en-US/Docs/powershell.md
+++ b/en-US/Docs/powershell.md
@@ -76,11 +76,10 @@ Make sure to follow these steps to correctly configure your device running Windo
 	        net user Administrator [new password]
 	        
 	b. Next, establish a new PowerShell session using `Exit-PSSession` and `Enter-PSSession` with the new credentials.
-	```
-	    	Exit-PSSession
-	    	
-	    	Enter-PSSession -ComputerName <machine-name or IP Address> -Credential <machine-name or IP Address or localhost>\Administrator
-	```
+	
+	        Exit-PSSession
+	        
+	        Enter-PSSession -ComputerName <machine-name or IP Address> -Credential <machine-name or IP Address or localhost>\Administrator
 
 ## Troubleshooting Visual Studio Remote Debugger
 ___


### PR DESCRIPTION
Instead of just indentation, triple backticks *and* indendation was used to render a code block as such. This lead to multiple rendering errors on the documentation page [https://developer.microsoft.com/en-us/windows/iot/docs/powershell](https://developer.microsoft.com/en-us/windows/iot/docs/powershell):
- Beginning triple backticks where visible outside of the code block
- `Exit-PSSession` supposed to be in the code block, but was outside of it
- Trailing triple backticks where visible inside the code block