### PR TITLE
Required library step not needed

### DIFF
--- a/en-US/Samples/arduino-wiring/LCDTextDisplay.md
+++ b/en-US/Samples/arduino-wiring/LCDTextDisplay.md
@@ -64,10 +64,6 @@ There is a fritzing diagram below, as well as a table of the exact pinouts we us
 |:-----------:|:----------------------:|
 | ![LCD Display]({{site.baseurl}}/Resources/images/arduino_wiring/lcd_16pins.jpg) | ![RPI Pinouts]({{site.baseurl}}/Resources/images/arduino_wiring/pi2_pinouts.png) |
 
-## Required Library
-
-You'll need the LiquidCrystal library, which is included in the Arduino SDK! You can copy the two files `LiquidCrystal.h` and `LiquidCrystal.cpp` from the Arduino libraries folder (typically C:\Program Files (x86)\Arduino\libraries\LiquidCrystal\src\) and paste them into your solution directory! Then, drag the two files from your solution directory into your project (via Solution Explorer) in Visual Studio.
-
 
 ## Code
 


### PR DESCRIPTION
The required library step, where it tells you to copy LiquidCrystal.h and LiquidCrystal.cpp into the VS project from the Arduino SDK, is obsolete. When you copy these into the project, the project doesn't compile because these files are already included in the Arduino Wiring template.