### PR TITLE
Add step for V2017 using Visual Studio Installer

### DIFF
--- a/en-US/Samples/HelloWorldPython.md
+++ b/en-US/Samples/HelloWorldPython.md
@@ -19,6 +19,8 @@ In this sample, we will create and deploy the proverbial 1st app, "Hello, world!
 
 * Download and install PTVS (Python Tools for Visual Studio) **VS 2015** latest release from [here](https://github.com/Microsoft/PTVS/releases/latest){:target="_blank"}.
 
+* In VS 2017 use Visual Studio Installer to ensure that you have Python IoT support installed.
+
 * Download and install the latest Python UWP SDK (pyuwpsdk.vsix) release from [here](https://github.com/ms-iot/python/releases){:target="_blank"}.
 
 ### Create new Python project


### PR DESCRIPTION
By default the Python IoT template isn't part of Visual Studio.  Just calling out that if you don't see it, make sure you install it with visual studio installer.