### PR TITLE
"Next Lesson 2" does not make sense to the user.

### DIFF
--- a/en-US/Samples/KitBlinky.md
+++ b/en-US/Samples/KitBlinky.md
@@ -76,7 +76,4 @@ Congratulations! You controlled one of the GPIO pins on your Windows IoT device.
 {% include samples/BlinkyCodeCS.md%}
 
 <div class="row lineTop">
-  <div class="text-right col-xs-24">
-    <h2 class="thin-header"><a href="{{site.baseurl}}/{{page.lang}}/Samples/WorldMapOfMakers">Next: Lesson 2 - Starter Projects</a></h2>
-  </div>
 </div>


### PR DESCRIPTION
Please remove the "Next Lesson 2" link at the bottom right. It seems like there wasn't a lot of thought behind putting that there, and it doesn't not even appear in the Adafruit Kit overview. It creates a jarring experience.