### PR TITLE
fixes ethernet networking speeds of Raspberry 2 and 3

### DIFF
--- a/en-US/Explore/SuggestedDevices.md
+++ b/en-US/Explore/SuggestedDevices.md
@@ -67,11 +67,11 @@
       <td>
         Wi-Fi 802.11 b/g/n
         <br>
-        10/100/1000 MBit/s Ethernet
+        10/100 MBit/s Ethernet
         <br>
         Bluetooth 4.1
       </td>
-      <td>10/100/1000 MBit/s Ethernet</td>
+      <td>10/100 MBit/s Ethernet</td>
       <td>10/100/1000 MBit/s Ethernet</td>
       <td>
         Wi-Fi 802.11 a/b/g/n


### PR DESCRIPTION
The Raspberry 2 and 3 models are only capable of 10/100 MBit/s ethernet speeds.
See https://en.wikipedia.org/wiki/Raspberry_Pi#Networking