### PR TITLE
Change Project Directory

### DIFF
--- a/en-US/Samples/HelloBlinky.md
+++ b/en-US/Samples/HelloBlinky.md
@@ -19,7 +19,7 @@ Also, be aware that the GPIO APIs are only available on Windows 10 IoT Core, so 
 ## Load the project in Visual Studio
 ___
 
-You can find the source code for this sample by downloading a zip of all of our samples [here](https://github.com/ms-iot/samples/archive/develop.zip) and navigating to the `samples-develop\Blinky`.  The sample code is available in either C++ or C#, however the documentation here only details the C# variant. Make a copy of the folder on your disk and open the project from Visual Studio.
+You can find the source code for this sample by downloading a zip of all of our samples [here](https://github.com/ms-iot/samples/archive/develop.zip) and navigating to the `samples-develop\HelloBlinky`.  The sample code is available in either C++ or C#, however the documentation here only details the C# variant. Make a copy of the folder on your disk and open the project from Visual Studio.
 
 ## Connect the LED to your Windows IoT device
 ___


### PR DESCRIPTION
According to the new samples-develop.zip file, we can find this sample under "samples-develop\HelloBlinky", not "samples-develop\Blinky".