### PR TITLE
Swaps 'C#' and 'C++' text in 'Create A Project' section

### DIFF
--- a/en-US/GetStarted/Prototype/WriteApp.htm
+++ b/en-US/GetStarted/Prototype/WriteApp.htm
@@ -63,12 +63,12 @@ lang: en-US
         </div>
         <button class="c-flipper f-next" aria-hidden="true" tabindex="-1"></button>
         <section class="pad-thin" data-grid="col-12" id="Pivot1Target1" role="tabpanel" aria-hidden="false">                   
-        <p class="c-paragraph-3"> To create a new C# project, start the Visual Studio IDE of your choice – we recommend Visual Studio 2017 – and create a new project from the file tab. In the New Project dialog, navigate to Universal and select the Blank App template</p>
+        <p class="c-paragraph-3"> To create a new C++ project, start the Visual Studio IDE of your choice – we recommend Visual Studio 2017 – and create a new project from the file tab. In the New Project dialog, navigate to Universal and select the Blank App template</p>
         <br>
         <img class="c-image" src="{{site.baseurl}}/Resources/images/NewProj-CPP.png" width="75%" alt="Create a new project">
         </section>
         <section class="pad-thin" data-grid="col-12" id="Pivot1Target2" role="tabpanel" aria-hidden="true">
-        <p class="c-paragraph-3"> To create a new C++ project, start the Visual Studio IDE of your choice – we recommend Visual Studio 2017 – and create a new project from the file tab. In the New Project dialog, navigate to Universal and select the Blank App template</p>
+        <p class="c-paragraph-3"> To create a new C# project, start the Visual Studio IDE of your choice – we recommend Visual Studio 2017 – and create a new project from the file tab. In the New Project dialog, navigate to Universal and select the Blank App template</p>
         <br>
         <img class="c-image" src="{{site.baseurl}}/Resources/images/NewProj-CS.png" width="75%" alt="Create a new project">
         </section>


### PR DESCRIPTION
The text was not matching the panel title and picture.